### PR TITLE
Implement a bare-bones set of opcodes

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -19,7 +19,10 @@
 #include "ilgen/VirtualMachineState.hpp"
 #include <type_traits>
 
-wabt::jit::FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::IstreamOffset const offset, TypeDictionary* types)
+namespace wabt {
+namespace jit {
+
+FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::IstreamOffset const offset, TypeDictionary* types)
     : TR::MethodBuilder(types),
       thread_(thread),
       offset_(offset),
@@ -32,7 +35,7 @@ wabt::jit::FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::Istr
   DefineReturnType(types->toIlType<std::underlying_type<wabt::interp::Result>::type>());
 }
 
-bool wabt::jit::FunctionBuilder::buildIL() {
+bool FunctionBuilder::buildIL() {
   using ValueEnum = std::underlying_type<wabt::interp::Result>::type;
   setVMState(new OMR::VirtualMachineState{});
 
@@ -58,7 +61,7 @@ bool wabt::jit::FunctionBuilder::buildIL() {
  * stack_base_addr[stack_top] = value;
  * *stack_top_addr = stack_top + 1;
  */
-void wabt::jit::FunctionBuilder::Push(TR::IlBuilder* b, const char* type, TR::IlValue* value) {
+void FunctionBuilder::Push(TR::IlBuilder* b, const char* type, TR::IlValue* value) {
   auto pInt32 = typeDictionary()->PointerTo(Int32);
   auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
   auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
@@ -84,7 +87,7 @@ void wabt::jit::FunctionBuilder::Push(TR::IlBuilder* b, const char* type, TR::Il
  * *stack_top_addr = new_stack_top;
  * return stack_base_addr[new_stack_top];
  */
-TR::IlValue* wabt::jit::FunctionBuilder::Pop(TR::IlBuilder* b, const char* type) {
+TR::IlValue* FunctionBuilder::Pop(TR::IlBuilder* b, const char* type) {
   auto pInt32 = typeDictionary()->PointerTo(Int32);
   auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
   auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
@@ -97,4 +100,7 @@ TR::IlValue* wabt::jit::FunctionBuilder::Pop(TR::IlBuilder* b, const char* type)
          b->             IndexAt(pValueType_,
                                  stack_base_addr,
                                  new_stack_top));
+}
+
+}
 }

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -242,6 +242,9 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       DropKeep(b, 1, 0);
       break;
 
+    case Opcode::Nop:
+      break;
+
     default:
       return false;
   }

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -168,9 +168,33 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       b->Return(b->Const(static_cast<ValueEnum>(interp::Result::Ok)));
       return true;
 
+    case Opcode::I32Const:
+      Push(b, "i32", b->ConstInt32(ReadU32(&pc)));
+      break;
+
+    case Opcode::I64Const:
+      Push(b, "i64", b->ConstInt64(ReadU64(&pc)));
+      break;
+
+    case Opcode::F32Const:
+      Push(b, "f32", b->ConstInt32(ReadU32(&pc)));
+      break;
+
+    case Opcode::F64Const:
+      Push(b, "f64", b->ConstInt64(ReadU64(&pc)));
+      break;
+
     default:
       return false;
   }
+
+  int32_t next_index = static_cast<int32_t>(workItems_.size());
+
+  workItems_.emplace_back(OrphanBytecodeBuilder(next_index,
+                                                const_cast<char*>(ReadOpcodeAt(pc).GetName())),
+                          pc);
+  b->AddFallThroughBuilder(workItems_[next_index].builder);
+  return true;
 }
 
 }

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -218,6 +218,10 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       b->Return(b->Const(static_cast<ValueEnum>(interp::Result::Ok)));
       return true;
 
+    case Opcode::Unreachable:
+      b->Return(b->Const(static_cast<ValueEnum>(interp::Result::TrapUnreachable)));
+      return true;
+
     case Opcode::I32Const:
       Push(b, "i32", b->ConstInt32(ReadU32(&pc)));
       break;

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -48,6 +48,14 @@ class FunctionBuilder : public TR::MethodBuilder {
    */
   TR::IlValue* Pop(TR::IlBuilder* b, const char* type);
 
+  /**
+   * @brief Drop a number of values from the interpreter stack, optionally keeping the top value of the stack
+   * @param b is the builder object used to generate the code
+   * @param drop_count is the number of values to drop from the stack
+   * @param keep_count is 1 to keep the top value intact and 0 otherwise
+   */
+  void DropKeep(TR::IlBuilder* b, uint32_t drop_count, uint8_t keep_count);
+
  private:
   struct BytecodeWorkItem {
     TR::BytecodeBuilder* builder;

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -18,6 +18,7 @@
 #define FUNCTIONBUILDER_HPP
 
 #include "type-dictionary.h"
+#include "ilgen/BytecodeBuilder.hpp"
 #include "ilgen/MethodBuilder.hpp"
 #include "ilgen/VirtualMachineOperandStack.hpp"
 
@@ -48,11 +49,23 @@ class FunctionBuilder : public TR::MethodBuilder {
   TR::IlValue* Pop(TR::IlBuilder* b, const char* type);
 
  private:
+  struct BytecodeWorkItem {
+    TR::BytecodeBuilder* builder;
+    const uint8_t* pc;
+
+    BytecodeWorkItem(TR::BytecodeBuilder* builder, const uint8_t* pc)
+      : builder(builder), pc(pc) {}
+  };
+
+  std::vector<BytecodeWorkItem> workItems_;
+
   interp::Thread* thread_;
   interp::IstreamOffset const offset_;
 
   TR::IlType* const valueType_;
   TR::IlType* const pValueType_;
+
+  bool Emit(TR::BytecodeBuilder* b, const uint8_t* istream, const uint8_t* pc);
 };
 
 }


### PR DESCRIPTION
This implements a very bare-bones set of opcodes that should be sufficient for compiling a `return 3` test (#15). The opcodes implemented are:

- `return` (#13)
- `i32.const`, `i64.const`, `f32.const`, and `f64.const` (#14)
- `drop`
- `select`
- `unreachable`
- `nop`

These implementations simply operate directly on the value stack used by the interpreter. This is definitely not the most efficient solution, since performing any actual operations this way requires extra loads and stores that could be easily avoided. However, this is the simplest solution and should suffice until we can implement something better.