### PR TITLE
Cache JITed function entry points

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -1329,7 +1329,16 @@ Result Thread::Run(int num_instructions) {
       case Opcode::Call: {
         IstreamOffset offset = ReadU32(&pc);
         if (env_->enable_jit) {
-          auto f = jit::compile(this, offset);
+          jit::JITedFunction f = nullptr;
+          auto fi = env_->jit_compiled_functions_.find(offset);
+
+          if (fi != env_->jit_compiled_functions_.end()) {
+            f = fi->second;
+          } else {
+            f = jit::compile(this, offset);
+            env_->jit_compiled_functions_.insert({offset, f});
+          }
+
           if (f) {
             CHECK_TRAP(f());
           } else {

--- a/src/interp.h
+++ b/src/interp.h
@@ -22,6 +22,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <unordered_map>
 
 #include "src/binding-hash.h"
 #include "src/common.h"
@@ -454,6 +455,7 @@ class Environment {
 
  private:
   friend class Thread;
+  using JITedFunction = wabt::interp::Result (*)();
 
   std::vector<std::unique_ptr<Module>> modules_;
   std::vector<FuncSignature> sigs_;
@@ -464,6 +466,7 @@ class Environment {
   std::unique_ptr<OutputBuffer> istream_;
   BindingHash module_bindings_;
   BindingHash registered_module_bindings_;
+  std::unordered_map<IstreamOffset, JITedFunction> jit_compiled_functions_;
 };
 
 class Thread {


### PR DESCRIPTION
Instead of unconditionally JIT compiling a function when it is called, a table
mapping function offsets to JITed function entry points is first checked. If the
table already contains an entry point for the current function, then the
function is simply called. If no entry is found, the function will be JIT
compiled. If compilation fails, `nullptr` is set in the table.

Closes #21