### PR TITLE
Add option to trap on failed JIT compilation

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -1337,6 +1337,7 @@ Result Thread::Run(int num_instructions) {
           } else {
             f = jit::compile(this, offset);
             env_->jit_compiled_functions_.insert({offset, f});
+            TRAP_IF(env_->trap_on_failed_comp && f == nullptr, FailedJITCompilation);
           }
 
           if (f) {

--- a/src/interp.h
+++ b/src/interp.h
@@ -68,6 +68,8 @@ namespace interp {
   V(TrapHostResultTypeMismatch, "host result type mismatch")                \
   /* we called an import function, but it didn't complete succesfully */    \
   V(TrapHostTrapped, "host function trapped")                               \
+  /* we attempted to JIT compile a function and failed */                   \
+  V(TrapFailedJITCompilation, "failed JIT compilation")                     \
   /* we attempted to call a function with the an argument list that doesn't \
    * match the function signature */                                        \
   V(ArgumentTypeMismatch, "argument type mismatch")                         \
@@ -347,7 +349,9 @@ class Environment {
     size_t globals_size = 0;
     size_t istream_size = 0;
   };
+
   bool enable_jit = true;
+  bool trap_on_failed_comp = false;
 
   Environment();
 

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -49,6 +49,7 @@ static Stream* s_trace_stream;
 static bool s_run_all_exports;
 static bool s_host_print;
 static bool s_disable_jit;
+static bool s_trap_on_failed_comp;
 static Features s_features;
 
 static std::unique_ptr<FileStream> s_log_stream;
@@ -112,6 +113,9 @@ static void ParseOptions(int argc, char** argv) {
   parser.AddOption("disable-jit",
                    "Prevent just in time compilation",
                    []() { s_disable_jit = true; });
+  parser.AddOption("trap-on-failed-comp",
+                   "Trap if a JIT compilation fails",
+                   []() { s_trap_on_failed_comp = true; });
 
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                      [](const char* argument) { s_infile = argument; });
@@ -230,7 +234,10 @@ static void InitEnvironment(Environment* env) {
     host_module->import_delegate.reset(new WasmInterpHostImportDelegate());
   }
   if (s_disable_jit) {
-      env->enable_jit = false;
+    env->enable_jit = false;
+  }
+  if (s_trap_on_failed_comp) {
+    env->trap_on_failed_comp = true;
   }
 }
 


### PR DESCRIPTION
Passing `--trap-on-failed-comp` when calling `wasm-interp` will now trap anytime
a JIT compilation fails. The failure message is "error: failed JIT compilation".

Closes #20