### PR TITLE
Add basic JIT testing functionality and return 3 tests.

### DIFF
--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -32,4 +32,5 @@ options:
       --run-all-exports                       Run all the exported functions, in order. Useful for testing
       --host-print                            Include an importable function named "host.print" for printing to stdout
       --disable-jit                           Prevent just in time compilation
+      --trap-on-failed-comp                   Trap if a JIT compilation fails
 ;;; STDOUT ;;)

--- a/test/jit/return_three.txt
+++ b/test/jit/return_three.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-interp-jit
+(module
+  (func (export "test_return_three") (result i32)
+    call $return_three)
+
+  (func $return_three (result i32)
+    i32.const 3
+    return)
+)
+(;; STDOUT ;;;
+test_return_three() => i32:3
+;;; STDOUT ;;)

--- a/test/jit/return_three.txt
+++ b/test/jit/return_three.txt
@@ -27,17 +27,10 @@
   (func $return_3_f64 (result f64)
     f64.const 3.0
     return)
-
-  (func (export "test_outer_func_not_compiled") (result i32)
-    call $return_3_i32
-    call $return_3_i32
-    i32.add
-    return)
 )
 (;; STDOUT ;;;
 test_return_3_i32() => i32:3
 test_return_3_i64() => i64:3
 test_return_3_f32() => f32:3.000000
 test_return_3_f64() => f64:3.000000
-test_outer_func_not_compiled() => i32:6
 ;;; STDOUT ;;)

--- a/test/jit/return_three.txt
+++ b/test/jit/return_three.txt
@@ -1,12 +1,43 @@
 ;;; TOOL: run-interp-jit
 (module
-  (func (export "test_return_three") (result i32)
-    call $return_three)
+  (func (export "test_return_3_i32") (result i32)
+    call $return_3_i32)
 
-  (func $return_three (result i32)
+  (func $return_3_i32 (result i32)
     i32.const 3
+    return)
+
+  (func (export "test_return_3_i64") (result i64)
+    call $return_3_i64)
+
+  (func $return_3_i64 (result i64)
+    i64.const 3
+    return)
+
+  (func (export "test_return_3_f32") (result f32)
+    call $return_3_f32)
+
+  (func $return_3_f32 (result f32)
+    f32.const 3.0
+    return)
+
+  (func (export "test_return_3_f64") (result f64)
+    call $return_3_f64)
+
+  (func $return_3_f64 (result f64)
+    f64.const 3.0
+    return)
+
+  (func (export "test_outer_func_not_compiled") (result i32)
+    call $return_3_i32
+    call $return_3_i32
+    i32.add
     return)
 )
 (;; STDOUT ;;;
-test_return_three() => i32:3
+test_return_3_i32() => i32:3
+test_return_3_i64() => i64:3
+test_return_3_f32() => f32:3.000000
+test_return_3_f64() => f64:3.000000
+test_outer_func_not_compiled() => i32:6
 ;;; STDOUT ;;)

--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -51,6 +51,7 @@ def main(args):
   parser.add_argument('--enable-saturating-float-to-int', action='store_true')
   parser.add_argument('--enable-threads', action='store_true')
   parser.add_argument('--disable-jit', action='store_true')
+  parser.add_argument('--trap-on-failed-comp', action='store_true')
   options = parser.parse_args(args)
 
   wast_tool = None
@@ -84,6 +85,7 @@ def main(args):
   interp_tool.AppendOptionalArgs({
       '-v': options.verbose,
       '--run-all-exports': options.run_all_exports,
+      '--trap-on-failed-comp': options.trap_on_failed_comp,
       '--trace': options.trace,
       '--enable-saturating-float-to-int':
           options.enable_saturating_float_to_int,

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -83,6 +83,7 @@ TOOLS = {
         'FLAGS': [
                 '--bindir=%(bindir)s',
                 '--run-all-exports',
+                '--trap-on-failed-comp',
                 '--no-error-cmdline',
                 '-o',
                 '%(out_dir)s',

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -78,6 +78,17 @@ TOOLS = {
         ],
         'VERBOSE-FLAGS': ['--print-cmd', '-v']
     },
+    'run-interp-jit': {
+        'EXE': 'test/run-interp.py',
+        'FLAGS': [
+                '--bindir=%(bindir)s',
+                '--run-all-exports',
+                '--no-error-cmdline',
+                '-o',
+                '%(out_dir)s',
+        ],
+        'VERBOSE-FLAGS': ['--print-cmd', '-v']
+    },
     'run-interp': {
         'EXE': 'test/run-interp.py',
         'FLAGS': [


### PR DESCRIPTION
- Adds basic functionality to test the JIT to WABT's testing suite under the tool configuration `run-interp-jit`.
- Adds basic tests for `return` and `i32`/`i64`/`f32`/`f64` `.const` opcodes to the JIT tests. 

Closes #8 