### PR TITLE
Make JIT initialization/shutdown transparent

### DIFF
--- a/src/interp.h
+++ b/src/interp.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include "src/jit/environment.h"
 #include "src/binding-hash.h"
 #include "src/common.h"
 #include "src/opcode.h"
@@ -470,6 +471,8 @@ class Environment {
   std::unique_ptr<OutputBuffer> istream_;
   BindingHash module_bindings_;
   BindingHash registered_module_bindings_;
+
+  jit::JitEnvironment jit_env_;
   std::unordered_map<IstreamOffset, JITedFunction> jit_compiled_functions_;
 };
 

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -15,6 +15,7 @@
 #
 
 add_library(wabtjit STATIC
+  environment.cc
   type-dictionary.cc
   function-builder.cc
   wabtjit.cc

--- a/src/jit/environment.cc
+++ b/src/jit/environment.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 wasmjit-omr project participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "environment.h"
+#include "Jit.hpp"
+
+namespace wabt {
+namespace jit {
+
+JitEnvironment::JitEnvironment() {
+  initializeJit();
+}
+
+JitEnvironment::~JitEnvironment() {
+  shutdownJit();
+}
+
+}
+}

--- a/src/jit/environment.h
+++ b/src/jit/environment.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 wasmjit-omr project participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JIT_ENVIRONMENT_HPP
+#define JIT_ENVIRONMENT_HPP
+
+namespace wabt {
+namespace jit {
+
+class JitEnvironment {
+public:
+  JitEnvironment();
+  ~JitEnvironment();
+};
+
+}
+}
+
+#endif // JIT_ENVIRONMENT_HPP

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -245,7 +245,6 @@ static wabt::Result ReadAndRunModule(const char* module_filename) {
   wabt::Result result;
   Environment env;
   InitEnvironment(&env);
-  initializeJit();
 
   ErrorHandlerFile error_handler(Location::Type::Binary);
   DefinedModule* module = nullptr;
@@ -261,7 +260,6 @@ static wabt::Result ReadAndRunModule(const char* module_filename) {
                   exec_result.result);
     }
   }
-  shutdownJit();
   return result;
 }
 


### PR DESCRIPTION
Previously, it was the responsibility of the program embedding the WABT interpreter to ensure that the JIT was initialized and shutdown at the correct times. However, this didn't really make sense since this is an internal implementation detail of the JIT. For this reason, JIT initialization and shutdown is now tied to the lifecycle of a `wabt::interp::Environment` object.