### PR TITLE
Update Tracis CI icon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/WebAssembly/wabt.svg?branch=master)](https://travis-ci.org/WebAssembly/wabt) [![Windows status](https://ci.appveyor.com/api/projects/status/79hqj5l0qggw645d/branch/master?svg=true)](https://ci.appveyor.com/project/WebAssembly/wabt/branch/master)
+[![Build Status](https://travis-ci.org/wasmjit-omr/wasmjit-omr.svg?branch=master)](https://travis-ci.org/wasmjit-omr/wasmjit-omr) [![Windows status](https://ci.appveyor.com/api/projects/status/79hqj5l0qggw645d/branch/master?svg=true)](https://ci.appveyor.com/project/WebAssembly/wabt/branch/master)
 
 # WABT: The WebAssembly Binary Toolkit
 


### PR DESCRIPTION
This commit simply updates the Travis CI icon in `README.md`.