### PR TITLE
Fix spec-interp and ensure its tests pass

### DIFF
--- a/src/jit/environment.cc
+++ b/src/jit/environment.cc
@@ -20,12 +20,18 @@
 namespace wabt {
 namespace jit {
 
+unsigned short JitEnvironment::instance_count_ = 0;
+
 JitEnvironment::JitEnvironment() {
-  initializeJit();
+  if (instance_count_ == 0)
+     initializeJit();
+  ++instance_count_;
 }
 
 JitEnvironment::~JitEnvironment() {
-  shutdownJit();
+  --instance_count_;
+  if (instance_count_ == 0)
+      shutdownJit();
 }
 
 }

--- a/src/jit/environment.h
+++ b/src/jit/environment.h
@@ -24,6 +24,8 @@ class JitEnvironment {
 public:
   JitEnvironment();
   ~JitEnvironment();
+private:
+  static unsigned short instance_count_;
 };
 
 }

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -922,6 +922,7 @@ class SpectestHostImportDelegate : public HostImportDelegate {
 static void InitEnvironment(Environment* env) {
   HostModule* host_module = env->AppendHostModule("spectest");
   host_module->import_delegate.reset(new SpectestHostImportDelegate());
+  env->enable_jit = false;
 }
 
 CommandRunner::CommandRunner()


### PR DESCRIPTION
To avoid having the JIT interfere with the `spec-interp` tool, it is
unconditionally disabled for this tool. In addition, instance counting
is added to `wabt::jit::JitEnvironment` to ensure the JIT is only
initialized once.

Fixes #30