### PR TITLE
Implement basic i32 arithmetic opcodes

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -18,10 +18,14 @@
 #include "src/interp.h"
 #include "ilgen/VirtualMachineState.hpp"
 #include "infra/Assert.hpp"
+
+#include <limits>
 #include <type_traits>
 
 namespace wabt {
 namespace jit {
+
+using ResultEnum = std::underlying_type<wabt::interp::Result>::type;
 
 // The following functions are required to be able to properly parse opcodes. However, their
 // original definitions are defined with static linkage in src/interp.cc. Because of this, the only
@@ -115,8 +119,6 @@ bool FunctionBuilder::buildIL() {
  * *stack_top_addr = stack_top + 1;
  */
 void FunctionBuilder::Push(TR::IlBuilder* b, const char* type, TR::IlValue* value) {
-  using ResultEnum = std::underlying_type<wabt::interp::Result>::type;
-
   auto pInt32 = typeDictionary()->PointerTo(Int32);
   auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
   auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
@@ -207,11 +209,62 @@ void FunctionBuilder::DropKeep(TR::IlBuilder* b, uint32_t drop_count, uint8_t ke
   b->StoreAt(stack_top_addr, new_stack_top);
 }
 
+template <>
+const char* FunctionBuilder::TypeFieldName<int32_t>() const {
+  return "i32";
+}
+
+template <>
+const char* FunctionBuilder::TypeFieldName<uint32_t>() const {
+  return "i32";
+}
+
+template <>
+const char* FunctionBuilder::TypeFieldName<int64_t>() const {
+  return "i64";
+}
+
+template <>
+const char* FunctionBuilder::TypeFieldName<uint64_t>() const {
+  return "i64";
+}
+
+template <typename T, typename TOpHandler>
+void FunctionBuilder::EmitBinaryOp(TR::IlBuilder* b, TOpHandler h) {
+  auto* rhs = Pop(b, TypeFieldName<T>());
+  auto* lhs = Pop(b, TypeFieldName<T>());
+
+  Push(b, TypeFieldName<T>(), h(lhs, rhs));
+}
+
+template <typename T>
+void FunctionBuilder::EmitIntDivide(TR::IlBuilder* b) {
+  static_assert(std::is_integral<T>::value,
+                "EmitIntDivide only works on integral types");
+
+  EmitBinaryOp<T>(b, [&](TR::IlValue* dividend, TR::IlValue* divisor) {
+    TR::IlBuilder* div_zero_path = nullptr;
+
+    b->IfThen(&div_zero_path, b->EqualTo(divisor, b->Const(static_cast<T>(0))));
+    div_zero_path->Return(div_zero_path->Const(
+        static_cast<ResultEnum>(interp::Result::TrapIntegerDivideByZero)));
+
+    TR::IlBuilder* div_ovf_path = nullptr;
+
+    b->IfThen(&div_ovf_path,
+    b->       And(
+    b->           EqualTo(dividend, b->Const(std::numeric_limits<T>::min())),
+    b->           EqualTo(divisor, b->Const(static_cast<T>(-1)))));
+    div_ovf_path->Return(div_ovf_path->Const(
+        static_cast<ResultEnum>(interp::Result::TrapIntegerOverflow)));
+
+    return b->Div(dividend, divisor);
+  });
+}
+
 bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
                            const uint8_t* istream,
                            const uint8_t* pc) {
-  using ValueEnum = std::underlying_type<wabt::interp::Result>::type;
-
   Opcode opcode = ReadOpcode(&pc);
   TR_ASSERT(!opcode.IsInvalid(), "Invalid opcode");
 
@@ -227,11 +280,11 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
     }
 
     case Opcode::Return:
-      b->Return(b->Const(static_cast<ValueEnum>(interp::Result::Ok)));
+      b->Return(b->Const(static_cast<ResultEnum>(interp::Result::Ok)));
       return true;
 
     case Opcode::Unreachable:
-      b->Return(b->Const(static_cast<ValueEnum>(interp::Result::TrapUnreachable)));
+      b->Return(b->Const(static_cast<ResultEnum>(interp::Result::TrapUnreachable)));
       return true;
 
     case Opcode::I32Const:
@@ -248,6 +301,28 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 
     case Opcode::F64Const:
       Push(b, "f64", b->ConstInt64(ReadU64(&pc)));
+      break;
+
+    case Opcode::I32Add:
+      EmitBinaryOp<int32_t>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->Add(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32Sub:
+      EmitBinaryOp<int32_t>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->Sub(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32Mul:
+      EmitBinaryOp<int32_t>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->Mul(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32DivS:
+      EmitIntDivide<int32_t>(b);
       break;
 
     case Opcode::Drop:

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -74,6 +74,9 @@ class FunctionBuilder : public TR::MethodBuilder {
   template <typename T>
   void EmitIntDivide(TR::IlBuilder* b);
 
+  template <typename T>
+  void EmitIntRemainder(TR::IlBuilder* b);
+
   std::vector<BytecodeWorkItem> workItems_;
 
   interp::Thread* thread_;

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -65,6 +65,15 @@ class FunctionBuilder : public TR::MethodBuilder {
       : builder(builder), pc(pc) {}
   };
 
+  template <typename T>
+  const char* TypeFieldName() const;
+
+  template <typename T, typename TOpHandler>
+  void EmitBinaryOp(TR::IlBuilder* b, TOpHandler h);
+
+  template <typename T>
+  void EmitIntDivide(TR::IlBuilder* b);
+
   std::vector<BytecodeWorkItem> workItems_;
 
   interp::Thread* thread_;


### PR DESCRIPTION
This pull request adds a number of basic i32 opcodes. At this point, only `i32.add`, `i32.sub`, `i32.mul`, and `i32.div_s` are supported. Support for `i32.rem_s` will be added when eclipse/omr#2216 is pulled to add support for emitting the necessary IL through `IlBuilder`. Closes #33.

@Leonardo2718 please review but do not merge until `i32.rem_s` support is added