### PR TITLE
Implement basic f32 arithmetic opcodes

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -327,11 +327,11 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       break;
 
     case Opcode::F32Const:
-      Push(b, "f32", b->ConstInt32(ReadU32(&pc)));
+      Push(b, "f32", b->ConstFloat(ReadUx<float>(&pc)));
       break;
 
     case Opcode::F64Const:
-      Push(b, "f64", b->ConstInt64(ReadU64(&pc)));
+      Push(b, "f64", b->ConstDouble(ReadUx<double>(&pc)));
       break;
 
     case Opcode::I32Add:

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -19,6 +19,7 @@
 #include "ilgen/VirtualMachineState.hpp"
 #include "infra/Assert.hpp"
 
+#include <cmath>
 #include <limits>
 #include <type_traits>
 
@@ -86,6 +87,18 @@ FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::IstreamOffset c
   DefineName("WASM_Function");
 
   DefineReturnType(types->toIlType<std::underlying_type<wabt::interp::Result>::type>());
+
+  DefineFunction("f32_sqrt", __FILE__, "0",
+                 reinterpret_cast<void*>(static_cast<float (*)(float)>(std::sqrt)),
+                 Float,
+                 1,
+                 Float);
+  DefineFunction("f32_copysign", __FILE__, "0",
+                 reinterpret_cast<void*>(static_cast<float (*)(float, float)>(std::copysign)),
+                 Float,
+                 2,
+                 Float,
+                 Float);
 }
 
 bool FunctionBuilder::buildIL() {
@@ -229,12 +242,27 @@ const char* FunctionBuilder::TypeFieldName<uint64_t>() const {
   return "i64";
 }
 
+template <>
+const char* FunctionBuilder::TypeFieldName<float>() const {
+  return "f32";
+}
+
+template <>
+const char* FunctionBuilder::TypeFieldName<double>() const {
+  return "f64";
+}
+
 template <typename T, typename TOpHandler>
 void FunctionBuilder::EmitBinaryOp(TR::IlBuilder* b, TOpHandler h) {
   auto* rhs = Pop(b, TypeFieldName<T>());
   auto* lhs = Pop(b, TypeFieldName<T>());
 
   Push(b, TypeFieldName<T>(), h(lhs, rhs));
+}
+
+template <typename T, typename TOpHandler>
+void FunctionBuilder::EmitUnaryOp(TR::IlBuilder* b, TOpHandler h) {
+  Push(b, TypeFieldName<T>(), h(Pop(b, TypeFieldName<T>())));
 }
 
 template <typename T>
@@ -440,6 +468,67 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 
     case Opcode::I64RemS:
       EmitIntRemainder<int64_t>(b);
+      break;
+
+    case Opcode::F32Abs:
+      EmitUnaryOp<float>(b, [&](TR::IlValue* value) {
+        auto* return_value = b->Copy(value);
+
+        TR::IlBuilder* zero_path = nullptr;
+        TR::IlBuilder* nonzero_path = nullptr;
+        TR::IlBuilder* neg_path = nullptr;
+
+        // We have to check explicitly for 0.0, since abs(-0.0) is 0.0.
+        b->IfThenElse(&zero_path, &nonzero_path, b->EqualTo(value, b->ConstFloat(0)));
+        zero_path->StoreOver(return_value, zero_path->ConstFloat(0));
+
+        nonzero_path->IfThen(&neg_path, nonzero_path->LessThan(value, nonzero_path->ConstFloat(0)));
+        neg_path->StoreOver(return_value, neg_path->Mul(value, neg_path->ConstFloat(-1)));
+
+        return return_value;
+      });
+      break;
+
+    case Opcode::F32Neg:
+      EmitUnaryOp<float>(b, [&](TR::IlValue* value) {
+        return b->Mul(value, b->ConstFloat(-1));
+      });
+      break;
+
+    case Opcode::F32Sqrt:
+      EmitUnaryOp<float>(b, [&](TR::IlValue* value) {
+        return b->Call("f32_sqrt", 1, value);
+      });
+      break;
+
+    case Opcode::F32Add:
+      EmitBinaryOp<float>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->Add(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F32Sub:
+      EmitBinaryOp<float>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->Sub(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F32Mul:
+      EmitBinaryOp<float>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->Mul(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F32Div:
+      EmitBinaryOp<float>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->Div(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F32Copysign:
+      EmitBinaryOp<float>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->Call("f32_copysign", 2, lhs, rhs);
+      });
       break;
 
     case Opcode::Drop:

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -71,6 +71,9 @@ class FunctionBuilder : public TR::MethodBuilder {
   template <typename T, typename TOpHandler>
   void EmitBinaryOp(TR::IlBuilder* b, TOpHandler h);
 
+  template <typename T, typename TOpHandler>
+  void EmitUnaryOp(TR::IlBuilder* b, TOpHandler h);
+
   template <typename T>
   void EmitIntDivide(TR::IlBuilder* b);
 

--- a/src/jit/type-dictionary.cc
+++ b/src/jit/type-dictionary.cc
@@ -22,7 +22,7 @@ wabt::jit::TypeDictionary::TypeDictionary() : TR::TypeDictionary() {
     DefineUnion("Value");
     UnionField("Value", "i32", toIlType<decltype(Value::i32)>());
     UnionField("Value", "i64", toIlType<decltype(Value::i64)>());
-    UnionField("Value", "f32", toIlType<decltype(Value::f32_bits)>());
-    UnionField("Value", "f64", toIlType<decltype(Value::f64_bits)>());
+    UnionField("Value", "f32", toIlType<float>());
+    UnionField("Value", "f64", toIlType<double>());
     CloseUnion("Value");
 }

--- a/test/jit/f32_arithmetic.txt
+++ b/test/jit/f32_arithmetic.txt
@@ -1,0 +1,704 @@
+;;; TOOL: run-interp-jit
+(module
+  (func (export "test_f32_abs_1") (result f32)
+    call $f32_abs_1)
+
+  (func $f32_abs_1 (result f32)
+    f32.const -1.0
+    f32.abs)
+
+  (func (export "test_f32_abs_2") (result f32)
+    call $f32_abs_2)
+
+  (func $f32_abs_2 (result f32)
+    f32.const 1.0
+    f32.abs)
+
+  (func (export "test_f32_abs_3") (result f32)
+    call $f32_abs_3)
+
+  (func $f32_abs_3 (result f32)
+    f32.const 0.0
+    f32.abs)
+
+  (func (export "test_f32_abs_4") (result f32)
+    call $f32_abs_4)
+
+  (func $f32_abs_4 (result f32)
+    f32.const -0.0
+    f32.abs)
+
+  (func (export "test_f32_abs_5") (result f32)
+    call $f32_abs_5)
+
+  (func $f32_abs_5 (result f32)
+    f32.const nan
+    f32.abs)
+
+  (func (export "test_f32_abs_6") (result f32)
+    call $f32_abs_6)
+
+  (func $f32_abs_6 (result f32)
+    f32.const inf
+    f32.abs)
+
+  (func (export "test_f32_abs_7") (result f32)
+    call $f32_abs_7)
+
+  (func $f32_abs_7 (result f32)
+    f32.const -inf
+    f32.abs)
+
+  (func (export "test_f32_neg_1") (result f32)
+    call $f32_neg_1)
+
+  (func $f32_neg_1 (result f32)
+    f32.const 1.0
+    f32.neg)
+
+  (func (export "test_f32_neg_2") (result f32)
+    call $f32_neg_2)
+
+  (func $f32_neg_2 (result f32)
+    f32.const -1.0
+    f32.neg)
+
+  (func (export "test_f32_neg_3") (result f32)
+    call $f32_neg_3)
+
+  (func $f32_neg_3 (result f32)
+    f32.const inf
+    f32.neg)
+
+  (func (export "test_f32_neg_4") (result f32)
+    call $f32_neg_4)
+
+  (func $f32_neg_4 (result f32)
+    f32.const -inf
+    f32.neg)
+
+  (func (export "test_f32_neg_5") (result f32)
+    call $f32_neg_5)
+
+  (func $f32_neg_5 (result f32)
+    f32.const 0.0
+    f32.neg)
+
+  (func (export "test_f32_neg_6") (result f32)
+    call $f32_neg_6)
+
+  (func $f32_neg_6 (result f32)
+    f32.const -0.0
+    f32.neg)
+
+  (func (export "test_f32_neg_7") (result f32)
+    call $f32_neg_7)
+
+  (func $f32_neg_7 (result f32)
+    f32.const nan
+    f32.neg)
+
+  (func (export "test_f32_sqrt_1") (result f32)
+    call $f32_sqrt_1)
+
+  (func $f32_sqrt_1 (result f32)
+    f32.const 2.0
+    f32.sqrt)
+
+  (func (export "test_f32_sqrt_2") (result f32)
+    call $f32_sqrt_2)
+
+  (func $f32_sqrt_2 (result f32)
+    f32.const 0.0
+    f32.sqrt)
+
+  (func (export "test_f32_sqrt_3") (result f32)
+    call $f32_sqrt_3)
+
+  (func $f32_sqrt_3 (result f32)
+    f32.const -0.0
+    f32.sqrt)
+
+  (func (export "test_f32_sqrt_4") (result f32)
+    call $f32_sqrt_4)
+
+  (func $f32_sqrt_4 (result f32)
+    f32.const inf
+    f32.sqrt)
+
+  (func (export "test_f32_sqrt_5") (result f32)
+    call $f32_sqrt_5)
+
+  (func $f32_sqrt_5 (result f32)
+    f32.const -1.0
+    f32.sqrt)
+
+  (func (export "test_f32_sqrt_6") (result f32)
+    call $f32_sqrt_6)
+
+  (func $f32_sqrt_6 (result f32)
+    f32.const nan
+    f32.sqrt)
+
+  (func (export "test_f32_add_1") (result f32)
+    call $f32_add_1)
+
+  (func $f32_add_1 (result f32)
+    f32.const 1.25
+    f32.const 2.25
+    f32.add)
+
+  (func (export "test_f32_add_2") (result f32)
+    call $f32_add_2)
+
+  (func $f32_add_2 (result f32)
+    f32.const -2.0
+    f32.const 1.0
+    f32.add)
+
+  (func (export "test_f32_add_3") (result f32)
+    call $f32_add_3)
+
+  (func $f32_add_3 (result f32)
+    f32.const 1.0
+    f32.const 0.0
+    f32.add)
+
+  (func (export "test_f32_add_4") (result f32)
+    call $f32_add_4)
+
+  (func $f32_add_4 (result f32)
+    f32.const nan
+    f32.const 0.0
+    f32.add)
+
+  (func (export "test_f32_add_5") (result f32)
+    call $f32_add_5)
+
+  (func $f32_add_5 (result f32)
+    f32.const 0.0
+    f32.const nan
+    f32.add)
+
+  (func (export "test_f32_add_6") (result f32)
+    call $f32_add_6)
+
+  (func $f32_add_6 (result f32)
+    f32.const inf
+    f32.const 0.0
+    f32.add)
+
+  (func (export "test_f32_add_7") (result f32)
+    call $f32_add_7)
+
+  (func $f32_add_7 (result f32)
+    f32.const 0.0
+    f32.const -inf
+    f32.add)
+
+  (func (export "test_f32_add_8") (result f32)
+    call $f32_add_8)
+
+  (func $f32_add_8 (result f32)
+    f32.const inf
+    f32.const -inf
+    f32.add)
+
+  (func (export "test_f32_add_9") (result f32)
+    call $f32_add_9)
+
+  (func $f32_add_9 (result f32)
+    f32.const inf
+    f32.const inf
+    f32.add)
+
+  (func (export "test_f32_add_10") (result f32)
+    call $f32_add_10)
+
+  (func $f32_add_10 (result f32)
+    f32.const -inf
+    f32.const -inf
+    f32.add)
+
+  (func (export "test_f32_sub_1") (result f32)
+    call $f32_sub_1)
+
+  (func $f32_sub_1 (result f32)
+    f32.const 1.25
+    f32.const 2.25
+    f32.sub)
+
+  (func (export "test_f32_sub_2") (result f32)
+    call $f32_sub_2)
+
+  (func $f32_sub_2 (result f32)
+    f32.const -2.0
+    f32.const 1.0
+    f32.sub)
+
+  (func (export "test_f32_sub_3") (result f32)
+    call $f32_sub_3)
+
+  (func $f32_sub_3 (result f32)
+    f32.const 1.0
+    f32.const 0.0
+    f32.sub)
+
+  (func (export "test_f32_sub_4") (result f32)
+    call $f32_sub_4)
+
+  (func $f32_sub_4 (result f32)
+    f32.const nan
+    f32.const 0.0
+    f32.sub)
+
+  (func (export "test_f32_sub_5") (result f32)
+    call $f32_sub_5)
+
+  (func $f32_sub_5 (result f32)
+    f32.const 0.0
+    f32.const nan
+    f32.sub)
+
+  (func (export "test_f32_sub_6") (result f32)
+    call $f32_sub_6)
+
+  (func $f32_sub_6 (result f32)
+    f32.const inf
+    f32.const 0.0
+    f32.sub)
+
+  (func (export "test_f32_sub_7") (result f32)
+    call $f32_sub_7)
+
+  (func $f32_sub_7 (result f32)
+    f32.const 0.0
+    f32.const -inf
+    f32.sub)
+
+  (func (export "test_f32_sub_8") (result f32)
+    call $f32_sub_8)
+
+  (func $f32_sub_8 (result f32)
+    f32.const inf
+    f32.const -inf
+    f32.sub)
+
+  (func (export "test_f32_sub_9") (result f32)
+    call $f32_sub_9)
+
+  (func $f32_sub_9 (result f32)
+    f32.const -inf
+    f32.const inf
+    f32.sub)
+
+  (func (export "test_f32_sub_10") (result f32)
+    call $f32_sub_10)
+
+  (func $f32_sub_10 (result f32)
+    f32.const inf
+    f32.const inf
+    f32.sub)
+
+  (func (export "test_f32_mul_1") (result f32)
+    call $f32_mul_1)
+
+  (func $f32_mul_1 (result f32)
+    f32.const 3.0
+    f32.const 2.0
+    f32.mul)
+
+  (func (export "test_f32_mul_2") (result f32)
+    call $f32_mul_2)
+
+  (func $f32_mul_2 (result f32)
+    f32.const 3.0
+    f32.const -2.0
+    f32.mul)
+
+  (func (export "test_f32_mul_3") (result f32)
+    call $f32_mul_3)
+
+  (func $f32_mul_3 (result f32)
+    f32.const 0.0
+    f32.const 0.0
+    f32.mul)
+
+  (func (export "test_f32_mul_4") (result f32)
+    call $f32_mul_4)
+
+  (func $f32_mul_4 (result f32)
+    f32.const 0.0
+    f32.const -0.0
+    f32.mul)
+
+  (func (export "test_f32_mul_5") (result f32)
+    call $f32_mul_5)
+
+  (func $f32_mul_5 (result f32)
+    f32.const inf
+    f32.const inf
+    f32.mul)
+
+  (func (export "test_f32_mul_6") (result f32)
+    call $f32_mul_6)
+
+  (func $f32_mul_6 (result f32)
+    f32.const inf
+    f32.const -inf
+    f32.mul)
+
+  (func (export "test_f32_mul_7") (result f32)
+    call $f32_mul_7)
+
+  (func $f32_mul_7 (result f32)
+    f32.const inf
+    f32.const 0.0
+    f32.mul)
+
+  (func (export "test_f32_mul_8") (result f32)
+    call $f32_mul_8)
+
+  (func $f32_mul_8 (result f32)
+    f32.const 2.0
+    f32.const inf
+    f32.mul)
+
+  (func (export "test_f32_mul_9") (result f32)
+    call $f32_mul_9)
+
+  (func $f32_mul_9 (result f32)
+    f32.const -2.0
+    f32.const inf
+    f32.mul)
+
+  (func (export "test_f32_mul_10") (result f32)
+    call $f32_mul_10)
+
+  (func $f32_mul_10 (result f32)
+    f32.const nan
+    f32.const 1.0
+    f32.mul)
+
+  (func (export "test_f32_div_1") (result f32)
+    call $f32_div_1)
+
+  (func $f32_div_1 (result f32)
+    f32.const 4.0
+    f32.const 2.0
+    f32.div)
+
+  (func (export "test_f32_div_2") (result f32)
+    call $f32_div_2)
+
+  (func $f32_div_2 (result f32)
+    f32.const 4.0
+    f32.const -2.0
+    f32.div)
+
+  (func (export "test_f32_div_3") (result f32)
+    call $f32_div_3)
+
+  (func $f32_div_3 (result f32)
+    f32.const inf
+    f32.const 2.0
+    f32.div)
+
+  (func (export "test_f32_div_4") (result f32)
+    call $f32_div_4)
+
+  (func $f32_div_4 (result f32)
+    f32.const -inf
+    f32.const 2.0
+    f32.div)
+
+  (func (export "test_f32_div_5") (result f32)
+    call $f32_div_5)
+
+  (func $f32_div_5 (result f32)
+    f32.const inf
+    f32.const 0.0
+    f32.div)
+
+  (func (export "test_f32_div_6") (result f32)
+    call $f32_div_6)
+
+  (func $f32_div_6 (result f32)
+    f32.const inf
+    f32.const -0.0
+    f32.div)
+
+  (func (export "test_f32_div_7") (result f32)
+    call $f32_div_7)
+
+  (func $f32_div_7 (result f32)
+    f32.const 2.0
+    f32.const inf
+    f32.div)
+
+  (func (export "test_f32_div_8") (result f32)
+    call $f32_div_8)
+
+  (func $f32_div_8 (result f32)
+    f32.const 2.0
+    f32.const -inf
+    f32.div)
+
+  (func (export "test_f32_div_9") (result f32)
+    call $f32_div_9)
+
+  (func $f32_div_9 (result f32)
+    f32.const 2.0
+    f32.const 0.0
+    f32.div)
+
+  (func (export "test_f32_div_10") (result f32)
+    call $f32_div_10)
+
+  (func $f32_div_10 (result f32)
+    f32.const 2.0
+    f32.const -0.0
+    f32.div)
+
+  (func (export "test_f32_div_11") (result f32)
+    call $f32_div_11)
+
+  (func $f32_div_11 (result f32)
+    f32.const 0.0
+    f32.const inf
+    f32.div)
+
+  (func (export "test_f32_div_12") (result f32)
+    call $f32_div_12)
+
+  (func $f32_div_12 (result f32)
+    f32.const 0.0
+    f32.const -inf
+    f32.div)
+
+  (func (export "test_f32_div_13") (result f32)
+    call $f32_div_13)
+
+  (func $f32_div_13 (result f32)
+    f32.const inf
+    f32.const inf
+    f32.div)
+
+  (func (export "test_f32_div_14") (result f32)
+    call $f32_div_14)
+
+  (func $f32_div_14 (result f32)
+    f32.const inf
+    f32.const -inf
+    f32.div)
+
+  (func (export "test_f32_div_15") (result f32)
+    call $f32_div_15)
+
+  (func $f32_div_15 (result f32)
+    f32.const 0.0
+    f32.const 0.0
+    f32.div)
+
+  (func (export "test_f32_div_16") (result f32)
+    call $f32_div_16)
+
+  (func $f32_div_16 (result f32)
+    f32.const 0.0
+    f32.const -0.0
+    f32.div)
+
+  (func (export "test_f32_div_17") (result f32)
+    call $f32_div_17)
+
+  (func $f32_div_17 (result f32)
+    f32.const nan
+    f32.const 2.0
+    f32.div)
+
+  (func (export "test_f32_div_18") (result f32)
+    call $f32_div_18)
+
+  (func $f32_div_18 (result f32)
+    f32.const 2.0
+    f32.const nan
+    f32.div)
+
+  (func (export "test_f32_copysign_1") (result f32)
+    call $f32_copysign_1)
+
+  (func $f32_copysign_1 (result f32)
+    f32.const 2.0
+    f32.const 1.0
+    f32.copysign)
+
+  (func (export "test_f32_copysign_2") (result f32)
+    call $f32_copysign_2)
+
+  (func $f32_copysign_2 (result f32)
+    f32.const 2.0
+    f32.const -1.0
+    f32.copysign)
+
+  (func (export "test_f32_copysign_3") (result f32)
+    call $f32_copysign_3)
+
+  (func $f32_copysign_3 (result f32)
+    f32.const -2.0
+    f32.const 1.0
+    f32.copysign)
+
+  (func (export "test_f32_copysign_4") (result f32)
+    call $f32_copysign_4)
+
+  (func $f32_copysign_4 (result f32)
+    f32.const -2.0
+    f32.const -1.0
+    f32.copysign)
+
+  (func (export "test_f32_copysign_5") (result f32)
+    call $f32_copysign_5)
+
+  (func $f32_copysign_5 (result f32)
+    f32.const 0.0
+    f32.const inf
+    f32.copysign)
+
+  (func (export "test_f32_copysign_6") (result f32)
+    call $f32_copysign_6)
+
+  (func $f32_copysign_6 (result f32)
+    f32.const 0.0
+    f32.const -inf
+    f32.copysign)
+
+  (func (export "test_f32_copysign_7") (result f32)
+    call $f32_copysign_7)
+
+  (func $f32_copysign_7 (result f32)
+    f32.const -0.0
+    f32.const inf
+    f32.copysign)
+
+  (func (export "test_f32_copysign_8") (result f32)
+    call $f32_copysign_8)
+
+  (func $f32_copysign_8 (result f32)
+    f32.const -0.0
+    f32.const -inf
+    f32.copysign)
+
+  (func (export "test_f32_copysign_9") (result f32)
+    call $f32_copysign_9)
+
+  (func $f32_copysign_9 (result f32)
+    f32.const 1.0
+    f32.const 0.0
+    f32.copysign)
+
+  (func (export "test_f32_copysign_10") (result f32)
+    call $f32_copysign_10)
+
+  (func $f32_copysign_10 (result f32)
+    f32.const 1.0
+    f32.const -0.0
+    f32.copysign)
+
+  (func (export "test_f32_copysign_11") (result f32)
+    call $f32_copysign_11)
+
+  (func $f32_copysign_11 (result f32)
+    f32.const -1.0
+    f32.const 0.0
+    f32.copysign)
+
+  (func (export "test_f32_copysign_12") (result f32)
+    call $f32_copysign_12)
+
+  (func $f32_copysign_12 (result f32)
+    f32.const -1.0
+    f32.const -0.0
+    f32.copysign)
+)
+(;; STDOUT ;;;
+test_f32_abs_1() => f32:1.000000
+test_f32_abs_2() => f32:1.000000
+test_f32_abs_3() => f32:0.000000
+test_f32_abs_4() => f32:0.000000
+test_f32_abs_5() => f32:nan
+test_f32_abs_6() => f32:inf
+test_f32_abs_7() => f32:inf
+test_f32_neg_1() => f32:-1.000000
+test_f32_neg_2() => f32:1.000000
+test_f32_neg_3() => f32:-inf
+test_f32_neg_4() => f32:inf
+test_f32_neg_5() => f32:-0.000000
+test_f32_neg_6() => f32:0.000000
+test_f32_neg_7() => f32:nan
+test_f32_sqrt_1() => f32:1.414214
+test_f32_sqrt_2() => f32:0.000000
+test_f32_sqrt_3() => f32:-0.000000
+test_f32_sqrt_4() => f32:inf
+test_f32_sqrt_5() => f32:-nan
+test_f32_sqrt_6() => f32:nan
+test_f32_add_1() => f32:3.500000
+test_f32_add_2() => f32:-1.000000
+test_f32_add_3() => f32:1.000000
+test_f32_add_4() => f32:nan
+test_f32_add_5() => f32:nan
+test_f32_add_6() => f32:inf
+test_f32_add_7() => f32:-inf
+test_f32_add_8() => f32:-nan
+test_f32_add_9() => f32:inf
+test_f32_add_10() => f32:-inf
+test_f32_sub_1() => f32:-1.000000
+test_f32_sub_2() => f32:-3.000000
+test_f32_sub_3() => f32:1.000000
+test_f32_sub_4() => f32:nan
+test_f32_sub_5() => f32:nan
+test_f32_sub_6() => f32:inf
+test_f32_sub_7() => f32:inf
+test_f32_sub_8() => f32:inf
+test_f32_sub_9() => f32:-inf
+test_f32_sub_10() => f32:-nan
+test_f32_mul_1() => f32:6.000000
+test_f32_mul_2() => f32:-6.000000
+test_f32_mul_3() => f32:0.000000
+test_f32_mul_4() => f32:-0.000000
+test_f32_mul_5() => f32:inf
+test_f32_mul_6() => f32:-inf
+test_f32_mul_7() => f32:-nan
+test_f32_mul_8() => f32:inf
+test_f32_mul_9() => f32:-inf
+test_f32_mul_10() => f32:nan
+test_f32_div_1() => f32:2.000000
+test_f32_div_2() => f32:-2.000000
+test_f32_div_3() => f32:inf
+test_f32_div_4() => f32:-inf
+test_f32_div_5() => f32:inf
+test_f32_div_6() => f32:-inf
+test_f32_div_7() => f32:0.000000
+test_f32_div_8() => f32:-0.000000
+test_f32_div_9() => f32:inf
+test_f32_div_10() => f32:-inf
+test_f32_div_11() => f32:0.000000
+test_f32_div_12() => f32:-0.000000
+test_f32_div_13() => f32:-nan
+test_f32_div_14() => f32:-nan
+test_f32_div_15() => f32:-nan
+test_f32_div_16() => f32:-nan
+test_f32_div_17() => f32:nan
+test_f32_div_18() => f32:nan
+test_f32_copysign_1() => f32:2.000000
+test_f32_copysign_2() => f32:-2.000000
+test_f32_copysign_3() => f32:2.000000
+test_f32_copysign_4() => f32:-2.000000
+test_f32_copysign_5() => f32:0.000000
+test_f32_copysign_6() => f32:-0.000000
+test_f32_copysign_7() => f32:0.000000
+test_f32_copysign_8() => f32:-0.000000
+test_f32_copysign_9() => f32:1.000000
+test_f32_copysign_10() => f32:-1.000000
+test_f32_copysign_11() => f32:1.000000
+test_f32_copysign_12() => f32:-1.000000
+;;; STDOUT ;;)


### PR DESCRIPTION
The basic f32.{abs,neg,sqrt,add,sub,mul,div,copysign} arithmetic opcodes
have been implemented in the JIT FunctionBuilder. Several of these are
currently using helper functions due to missing functionality in
JitBuilder but could theoretically be replaced with inline
implementations in the future.

Closes #37