### PR TITLE
Implement i32 bitwise opcodes

### DIFF
--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -77,6 +77,9 @@ class FunctionBuilder : public TR::MethodBuilder {
   template <typename T>
   void EmitIntRemainder(TR::IlBuilder* b);
 
+  template <typename>
+  TR::IlValue* CalculateShiftAmount(TR::IlBuilder* b, TR::IlValue* amount);
+
   std::vector<BytecodeWorkItem> workItems_;
 
   interp::Thread* thread_;

--- a/test/jit/i32_bitwise.txt
+++ b/test/jit/i32_bitwise.txt
@@ -1,0 +1,230 @@
+;;; TOOL: run-interp-jit
+(module
+  (func (export "test_i32_and_1") (result i32)
+    call $i32_and_1)
+
+  (func $i32_and_1 (result i32)
+    i32.const 0x15
+    i32.const 0x13
+    i32.and)
+
+  (func (export "test_i32_and_2") (result i32)
+    call $i32_and_2)
+
+  (func $i32_and_2 (result i32)
+    i32.const 0x0
+    i32.const 0xffffffff
+    i32.and)
+
+  (func (export "test_i32_or_1") (result i32)
+    call $i32_or_1)
+
+  (func $i32_or_1 (result i32)
+    i32.const 0x15
+    i32.const 0x13
+    i32.or)
+
+  (func (export "test_i32_or_2") (result i32)
+    call $i32_or_2)
+
+  (func $i32_or_2 (result i32)
+    i32.const 0x0
+    i32.const 0xffffffff
+    i32.or)
+
+  (func (export "test_i32_xor_1") (result i32)
+    call $i32_xor_1)
+
+  (func $i32_xor_1 (result i32)
+    i32.const 0x15
+    i32.const 0x13
+    i32.xor)
+
+  (func (export "test_i32_xor_2") (result i32)
+    call $i32_xor_2)
+
+  (func $i32_xor_2 (result i32)
+    i32.const 0x0
+    i32.const 0xffffffff
+    i32.xor)
+
+  (func (export "test_i32_shl_1") (result i32)
+    call $i32_shl_1)
+
+  (func $i32_shl_1 (result i32)
+    i32.const 1
+    i32.const 0
+    i32.shl)
+
+  (func (export "test_i32_shl_2") (result i32)
+    call $i32_shl_2)
+
+  (func $i32_shl_2 (result i32)
+    i32.const 1
+    i32.const 3
+    i32.shl)
+
+  (func (export "test_i32_shl_3") (result i32)
+    call $i32_shl_3)
+
+  (func $i32_shl_3 (result i32)
+    i32.const 1
+    i32.const 33
+    i32.shl)
+
+  (func (export "test_i32_shr_s_1") (result i32)
+    call $i32_shr_s_1)
+
+  (func $i32_shr_s_1 (result i32)
+    i32.const 0x10
+    i32.const 0
+    i32.shr_s)
+
+  (func (export "test_i32_shr_s_2") (result i32)
+    call $i32_shr_s_2)
+
+  (func $i32_shr_s_2 (result i32)
+    i32.const 0x10
+    i32.const 3
+    i32.shr_s)
+
+  (func (export "test_i32_shr_s_3") (result i32)
+    call $i32_shr_s_3)
+
+  (func $i32_shr_s_3 (result i32)
+    i32.const 0x10
+    i32.const 33
+    i32.shr_s)
+
+  (func (export "test_i32_shr_s_4") (result i32)
+    call $i32_shr_s_4)
+
+  (func $i32_shr_s_4 (result i32)
+    i32.const -1
+    i32.const 10
+    i32.shr_s)
+
+  (func (export "test_i32_shr_u_1") (result i32)
+    call $i32_shr_u_1)
+
+  (func $i32_shr_u_1 (result i32)
+    i32.const 0x10
+    i32.const 0
+    i32.shr_u)
+
+  (func (export "test_i32_shr_u_2") (result i32)
+    call $i32_shr_u_2)
+
+  (func $i32_shr_u_2 (result i32)
+    i32.const 0x10
+    i32.const 3
+    i32.shr_u)
+
+  (func (export "test_i32_shr_u_3") (result i32)
+    call $i32_shr_u_3)
+
+  (func $i32_shr_u_3 (result i32)
+    i32.const 0x10
+    i32.const 33
+    i32.shr_u)
+
+  (func (export "test_i32_shr_u_4") (result i32)
+    call $i32_shr_u_4)
+
+  (func $i32_shr_u_4 (result i32)
+    i32.const -1
+    i32.const 10
+    i32.shr_u)
+
+  (func (export "test_i32_rotl_1") (result i32)
+    call $i32_rotl_1)
+
+  (func $i32_rotl_1 (result i32)
+    i32.const 0x1
+    i32.const 0
+    i32.rotl)
+
+  (func (export "test_i32_rotl_2") (result i32)
+    call $i32_rotl_2)
+
+  (func $i32_rotl_2 (result i32)
+    i32.const 0x1
+    i32.const 5
+    i32.rotl)
+
+  (func (export "test_i32_rotl_3") (result i32)
+    call $i32_rotl_3)
+
+  (func $i32_rotl_3 (result i32)
+    i32.const 0x10001000
+    i32.const 5
+    i32.rotl)
+
+  (func (export "test_i32_rotl_4") (result i32)
+    call $i32_rotl_4)
+
+  (func $i32_rotl_4 (result i32)
+    i32.const 0x10001000
+    i32.const 33
+    i32.rotl)
+
+  (func (export "test_i32_rotr_1") (result i32)
+    call $i32_rotr_1)
+
+  (func $i32_rotr_1 (result i32)
+    i32.const 0x10
+    i32.const 0
+    i32.rotr)
+
+  (func (export "test_i32_rotr_2") (result i32)
+    call $i32_rotr_2)
+
+  (func $i32_rotr_2 (result i32)
+    i32.const 0x10
+    i32.const 3
+    i32.rotr)
+
+  (func (export "test_i32_rotr_3") (result i32)
+    call $i32_rotr_3)
+
+  (func $i32_rotr_3 (result i32)
+    i32.const 0x00010001
+    i32.const 5
+    i32.rotr)
+
+  (func (export "test_i32_rotr_4") (result i32)
+    call $i32_rotr_4)
+
+  (func $i32_rotr_4 (result i32)
+    i32.const 0x00010001
+    i32.const 33
+    i32.rotr)
+)
+(;; STDOUT ;;;
+test_i32_and_1() => i32:17
+test_i32_and_2() => i32:0
+test_i32_or_1() => i32:23
+test_i32_or_2() => i32:4294967295
+test_i32_xor_1() => i32:6
+test_i32_xor_2() => i32:4294967295
+test_i32_shl_1() => i32:1
+test_i32_shl_2() => i32:8
+test_i32_shl_3() => i32:2
+test_i32_shr_s_1() => i32:16
+test_i32_shr_s_2() => i32:2
+test_i32_shr_s_3() => i32:8
+test_i32_shr_s_4() => i32:4294967295
+test_i32_shr_u_1() => i32:16
+test_i32_shr_u_2() => i32:2
+test_i32_shr_u_3() => i32:8
+test_i32_shr_u_4() => i32:4194303
+test_i32_rotl_1() => i32:1
+test_i32_rotl_2() => i32:32
+test_i32_rotl_3() => i32:131074
+test_i32_rotl_4() => i32:536879104
+test_i32_rotr_1() => i32:16
+test_i32_rotr_2() => i32:2
+test_i32_rotr_3() => i32:134219776
+test_i32_rotr_4() => i32:2147516416
+
+;;; STDOUT ;;)


### PR DESCRIPTION
The i32.{and,or,xor,shl,shr_s,shr_u,rotl,rotr} opcodes have been
implemented. Currently, the i32.rotl and i32.rotr opcodes use multiple
bitwise operations to compute their results. OMR does internally support
opcodes for performing bitwise rotations, but these are not currently
exposed by IlBuilder.

Closes #38