### PR TITLE
Implement f32 comparison opcodes

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -272,17 +272,17 @@ const char* FunctionBuilder::TypeFieldName<double>() const {
   return "f64";
 }
 
-template <typename T, typename TOpHandler>
+template <typename T, typename TResult, typename TOpHandler>
 void FunctionBuilder::EmitBinaryOp(TR::IlBuilder* b, TOpHandler h) {
   auto* rhs = Pop(b, TypeFieldName<T>());
   auto* lhs = Pop(b, TypeFieldName<T>());
 
-  Push(b, TypeFieldName<T>(), h(lhs, rhs));
+  Push(b, TypeFieldName<TResult>(), h(lhs, rhs));
 }
 
-template <typename T, typename TOpHandler>
+template <typename T, typename TResult, typename TOpHandler>
 void FunctionBuilder::EmitUnaryOp(TR::IlBuilder* b, TOpHandler h) {
-  Push(b, TypeFieldName<T>(), h(Pop(b, TypeFieldName<T>())));
+  Push(b, TypeFieldName<TResult>(), h(Pop(b, TypeFieldName<T>())));
 }
 
 template <typename T>

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -570,6 +570,42 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       });
       break;
 
+    case Opcode::F32Eq:
+      EmitBinaryOp<float, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->EqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F32Ne:
+      EmitBinaryOp<float, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->NotEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F32Lt:
+      EmitBinaryOp<float, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->LessThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F32Le:
+      EmitBinaryOp<float, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->LessOrEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F32Gt:
+      EmitBinaryOp<float, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->GreaterThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F32Ge:
+      EmitBinaryOp<float, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->GreaterOrEqualTo(lhs, rhs);
+      });
+      break;
+
     case Opcode::InterpAlloca: {
       auto pInt32 = typeDictionary()->PointerTo(Int32);
       auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -82,10 +82,10 @@ class FunctionBuilder : public TR::MethodBuilder {
   template <typename T>
   const char* TypeFieldName() const;
 
-  template <typename T, typename TOpHandler>
+  template <typename T, typename TResult = T, typename TOpHandler>
   void EmitBinaryOp(TR::IlBuilder* b, TOpHandler h);
 
-  template <typename T, typename TOpHandler>
+  template <typename T, typename TResult = T, typename TOpHandler>
   void EmitUnaryOp(TR::IlBuilder* b, TOpHandler h);
 
   template <typename T>

--- a/test/jit/f32_comparison.txt
+++ b/test/jit/f32_comparison.txt
@@ -1,0 +1,580 @@
+;;; TOOL: run-interp-jit
+(module
+  (func (export "test_f32_eq_1") (result i32)
+    call $f32_eq_1)
+
+  (func $f32_eq_1 (result i32)
+    f32.const 1.0
+    f32.const 1.0
+    f32.eq)
+
+  (func (export "test_f32_eq_2") (result i32)
+    call $f32_eq_2)
+
+  (func $f32_eq_2 (result i32)
+    f32.const 1.0
+    f32.const -1.0
+    f32.eq)
+
+  (func (export "test_f32_eq_3") (result i32)
+    call $f32_eq_3)
+
+  (func $f32_eq_3 (result i32)
+    f32.const 1.0
+    f32.const 3.0
+    f32.eq)
+
+  (func (export "test_f32_eq_4") (result i32)
+    call $f32_eq_4)
+
+  (func $f32_eq_4 (result i32)
+    f32.const 0.0
+    f32.const 0.0
+    f32.eq)
+
+  (func (export "test_f32_eq_5") (result i32)
+    call $f32_eq_5)
+
+  (func $f32_eq_5 (result i32)
+    f32.const -0.0
+    f32.const 0.0
+    f32.eq)
+
+  (func (export "test_f32_eq_6") (result i32)
+    call $f32_eq_6)
+
+  (func $f32_eq_6 (result i32)
+    f32.const nan
+    f32.const 0.0
+    f32.eq)
+
+  (func (export "test_f32_eq_7") (result i32)
+    call $f32_eq_7)
+
+  (func $f32_eq_7 (result i32)
+    f32.const nan
+    f32.const nan
+    f32.eq)
+
+  (func (export "test_f32_eq_8") (result i32)
+    call $f32_eq_8)
+
+  (func $f32_eq_8 (result i32)
+    f32.const inf
+    f32.const inf
+    f32.eq)
+
+  (func (export "test_f32_eq_9") (result i32)
+    call $f32_eq_9)
+
+  (func $f32_eq_9 (result i32)
+    f32.const -inf
+    f32.const -inf
+    f32.eq)
+
+  (func (export "test_f32_eq_10") (result i32)
+    call $f32_eq_10)
+
+  (func $f32_eq_10 (result i32)
+    f32.const inf
+    f32.const -inf
+    f32.eq)
+
+  (func (export "test_f32_ne_1") (result i32)
+    call $f32_ne_1)
+
+  (func $f32_ne_1 (result i32)
+    f32.const 1.0
+    f32.const 1.0
+    f32.ne)
+
+  (func (export "test_f32_ne_2") (result i32)
+    call $f32_ne_2)
+
+  (func $f32_ne_2 (result i32)
+    f32.const 1.0
+    f32.const -1.0
+    f32.ne)
+
+  (func (export "test_f32_ne_3") (result i32)
+    call $f32_ne_3)
+
+  (func $f32_ne_3 (result i32)
+    f32.const 1.0
+    f32.const 3.0
+    f32.ne)
+
+  (func (export "test_f32_ne_4") (result i32)
+    call $f32_ne_4)
+
+  (func $f32_ne_4 (result i32)
+    f32.const 0.0
+    f32.const 0.0
+    f32.ne)
+
+  (func (export "test_f32_ne_5") (result i32)
+    call $f32_ne_5)
+
+  (func $f32_ne_5 (result i32)
+    f32.const -0.0
+    f32.const 0.0
+    f32.ne)
+
+  (func (export "test_f32_ne_6") (result i32)
+    call $f32_ne_6)
+
+  (func $f32_ne_6 (result i32)
+    f32.const nan
+    f32.const 0.0
+    f32.ne)
+
+  (func (export "test_f32_ne_7") (result i32)
+    call $f32_ne_7)
+
+  (func $f32_ne_7 (result i32)
+    f32.const nan
+    f32.const nan
+    f32.ne)
+
+  (func (export "test_f32_ne_8") (result i32)
+    call $f32_ne_8)
+
+  (func $f32_ne_8 (result i32)
+    f32.const inf
+    f32.const inf
+    f32.ne)
+
+  (func (export "test_f32_ne_9") (result i32)
+    call $f32_ne_9)
+
+  (func $f32_ne_9 (result i32)
+    f32.const -inf
+    f32.const -inf
+    f32.ne)
+
+  (func (export "test_f32_ne_10") (result i32)
+    call $f32_ne_10)
+
+  (func $f32_ne_10 (result i32)
+    f32.const inf
+    f32.const -inf
+    f32.ne)
+
+  (func (export "test_f32_lt_1") (result i32)
+    call $f32_lt_1)
+
+  (func $f32_lt_1 (result i32)
+    f32.const 1.0
+    f32.const 1.0
+    f32.lt)
+
+  (func (export "test_f32_lt_2") (result i32)
+    call $f32_lt_2)
+
+  (func $f32_lt_2 (result i32)
+    f32.const 1.0
+    f32.const 1.1
+    f32.lt)
+
+  (func (export "test_f32_lt_3") (result i32)
+    call $f32_lt_3)
+
+  (func $f32_lt_3 (result i32)
+    f32.const 1.0
+    f32.const 0.9
+    f32.lt)
+
+  (func (export "test_f32_lt_4") (result i32)
+    call $f32_lt_4)
+
+  (func $f32_lt_4 (result i32)
+    f32.const 1.0
+    f32.const inf
+    f32.lt)
+
+  (func (export "test_f32_lt_5") (result i32)
+    call $f32_lt_5)
+
+  (func $f32_lt_5 (result i32)
+    f32.const 1.0
+    f32.const -inf
+    f32.lt)
+
+  (func (export "test_f32_lt_6") (result i32)
+    call $f32_lt_6)
+
+  (func $f32_lt_6 (result i32)
+    f32.const inf
+    f32.const inf
+    f32.lt)
+
+  (func (export "test_f32_lt_7") (result i32)
+    call $f32_lt_7)
+
+  (func $f32_lt_7 (result i32)
+    f32.const -inf
+    f32.const inf
+    f32.lt)
+
+  (func (export "test_f32_lt_8") (result i32)
+    call $f32_lt_8)
+
+  (func $f32_lt_8 (result i32)
+    f32.const inf
+    f32.const -inf
+    f32.lt)
+
+  (func (export "test_f32_lt_9") (result i32)
+    call $f32_lt_9)
+
+  (func $f32_lt_9 (result i32)
+    f32.const -inf
+    f32.const -inf
+    f32.lt)
+
+  (func (export "test_f32_lt_10") (result i32)
+    call $f32_lt_10)
+
+  (func $f32_lt_10 (result i32)
+    f32.const nan
+    f32.const 0.0
+    f32.lt)
+
+  (func (export "test_f32_lt_11") (result i32)
+    call $f32_lt_11)
+
+  (func $f32_lt_11 (result i32)
+    f32.const nan
+    f32.const nan
+    f32.lt)
+
+  (func (export "test_f32_le_1") (result i32)
+    call $f32_le_1)
+
+  (func $f32_le_1 (result i32)
+    f32.const 1.0
+    f32.const 1.0
+    f32.le)
+
+  (func (export "test_f32_le_2") (result i32)
+    call $f32_le_2)
+
+  (func $f32_le_2 (result i32)
+    f32.const 1.0
+    f32.const 1.1
+    f32.le)
+
+  (func (export "test_f32_le_3") (result i32)
+    call $f32_le_3)
+
+  (func $f32_le_3 (result i32)
+    f32.const 1.0
+    f32.const 0.9
+    f32.le)
+
+  (func (export "test_f32_le_4") (result i32)
+    call $f32_le_4)
+
+  (func $f32_le_4 (result i32)
+    f32.const 1.0
+    f32.const inf
+    f32.le)
+
+  (func (export "test_f32_le_5") (result i32)
+    call $f32_le_5)
+
+  (func $f32_le_5 (result i32)
+    f32.const 1.0
+    f32.const -inf
+    f32.le)
+
+  (func (export "test_f32_le_6") (result i32)
+    call $f32_le_6)
+
+  (func $f32_le_6 (result i32)
+    f32.const inf
+    f32.const inf
+    f32.le)
+
+  (func (export "test_f32_le_7") (result i32)
+    call $f32_le_7)
+
+  (func $f32_le_7 (result i32)
+    f32.const -inf
+    f32.const inf
+    f32.le)
+
+  (func (export "test_f32_le_8") (result i32)
+    call $f32_le_8)
+
+  (func $f32_le_8 (result i32)
+    f32.const inf
+    f32.const -inf
+    f32.le)
+
+  (func (export "test_f32_le_9") (result i32)
+    call $f32_le_9)
+
+  (func $f32_le_9 (result i32)
+    f32.const -inf
+    f32.const -inf
+    f32.le)
+
+  (func (export "test_f32_le_10") (result i32)
+    call $f32_le_10)
+
+  (func $f32_le_10 (result i32)
+    f32.const nan
+    f32.const 0.0
+    f32.le)
+
+  (func (export "test_f32_le_11") (result i32)
+    call $f32_le_11)
+
+  (func $f32_le_11 (result i32)
+    f32.const nan
+    f32.const nan
+    f32.le)
+
+  (func (export "test_f32_gt_1") (result i32)
+    call $f32_gt_1)
+
+  (func $f32_gt_1 (result i32)
+    f32.const 1.0
+    f32.const 1.0
+    f32.gt)
+
+  (func (export "test_f32_gt_2") (result i32)
+    call $f32_gt_2)
+
+  (func $f32_gt_2 (result i32)
+    f32.const 1.0
+    f32.const 1.1
+    f32.gt)
+
+  (func (export "test_f32_gt_3") (result i32)
+    call $f32_gt_3)
+
+  (func $f32_gt_3 (result i32)
+    f32.const 1.0
+    f32.const 0.9
+    f32.gt)
+
+  (func (export "test_f32_gt_4") (result i32)
+    call $f32_gt_4)
+
+  (func $f32_gt_4 (result i32)
+    f32.const 1.0
+    f32.const inf
+    f32.gt)
+
+  (func (export "test_f32_gt_5") (result i32)
+    call $f32_gt_5)
+
+  (func $f32_gt_5 (result i32)
+    f32.const 1.0
+    f32.const -inf
+    f32.gt)
+
+  (func (export "test_f32_gt_6") (result i32)
+    call $f32_gt_6)
+
+  (func $f32_gt_6 (result i32)
+    f32.const inf
+    f32.const inf
+    f32.gt)
+
+  (func (export "test_f32_gt_7") (result i32)
+    call $f32_gt_7)
+
+  (func $f32_gt_7 (result i32)
+    f32.const -inf
+    f32.const inf
+    f32.gt)
+
+  (func (export "test_f32_gt_8") (result i32)
+    call $f32_gt_8)
+
+  (func $f32_gt_8 (result i32)
+    f32.const inf
+    f32.const -inf
+    f32.gt)
+
+  (func (export "test_f32_gt_9") (result i32)
+    call $f32_gt_9)
+
+  (func $f32_gt_9 (result i32)
+    f32.const -inf
+    f32.const -inf
+    f32.gt)
+
+  (func (export "test_f32_gt_10") (result i32)
+    call $f32_gt_10)
+
+  (func $f32_gt_10 (result i32)
+    f32.const nan
+    f32.const 0.0
+    f32.gt)
+
+  (func (export "test_f32_gt_11") (result i32)
+    call $f32_gt_11)
+
+  (func $f32_gt_11 (result i32)
+    f32.const nan
+    f32.const nan
+    f32.gt)
+
+  (func (export "test_f32_ge_1") (result i32)
+    call $f32_ge_1)
+
+  (func $f32_ge_1 (result i32)
+    f32.const 1.0
+    f32.const 1.0
+    f32.ge)
+
+  (func (export "test_f32_ge_2") (result i32)
+    call $f32_ge_2)
+
+  (func $f32_ge_2 (result i32)
+    f32.const 1.0
+    f32.const 1.1
+    f32.ge)
+
+  (func (export "test_f32_ge_3") (result i32)
+    call $f32_ge_3)
+
+  (func $f32_ge_3 (result i32)
+    f32.const 1.0
+    f32.const 0.9
+    f32.ge)
+
+  (func (export "test_f32_ge_4") (result i32)
+    call $f32_ge_4)
+
+  (func $f32_ge_4 (result i32)
+    f32.const 1.0
+    f32.const inf
+    f32.ge)
+
+  (func (export "test_f32_ge_5") (result i32)
+    call $f32_ge_5)
+
+  (func $f32_ge_5 (result i32)
+    f32.const 1.0
+    f32.const -inf
+    f32.ge)
+
+  (func (export "test_f32_ge_6") (result i32)
+    call $f32_ge_6)
+
+  (func $f32_ge_6 (result i32)
+    f32.const inf
+    f32.const inf
+    f32.ge)
+
+  (func (export "test_f32_ge_7") (result i32)
+    call $f32_ge_7)
+
+  (func $f32_ge_7 (result i32)
+    f32.const -inf
+    f32.const inf
+    f32.ge)
+
+  (func (export "test_f32_ge_8") (result i32)
+    call $f32_ge_8)
+
+  (func $f32_ge_8 (result i32)
+    f32.const inf
+    f32.const -inf
+    f32.ge)
+
+  (func (export "test_f32_ge_9") (result i32)
+    call $f32_ge_9)
+
+  (func $f32_ge_9 (result i32)
+    f32.const -inf
+    f32.const -inf
+    f32.ge)
+
+  (func (export "test_f32_ge_10") (result i32)
+    call $f32_ge_10)
+
+  (func $f32_ge_10 (result i32)
+    f32.const nan
+    f32.const 0.0
+    f32.ge)
+
+  (func (export "test_f32_ge_11") (result i32)
+    call $f32_ge_11)
+
+  (func $f32_ge_11 (result i32)
+    f32.const nan
+    f32.const nan
+    f32.ge)
+)
+(;; STDOUT ;;;
+test_f32_eq_1() => i32:1
+test_f32_eq_2() => i32:0
+test_f32_eq_3() => i32:0
+test_f32_eq_4() => i32:1
+test_f32_eq_5() => i32:1
+test_f32_eq_6() => i32:0
+test_f32_eq_7() => i32:0
+test_f32_eq_8() => i32:1
+test_f32_eq_9() => i32:1
+test_f32_eq_10() => i32:0
+test_f32_ne_1() => i32:0
+test_f32_ne_2() => i32:1
+test_f32_ne_3() => i32:1
+test_f32_ne_4() => i32:0
+test_f32_ne_5() => i32:0
+test_f32_ne_6() => i32:0
+test_f32_ne_7() => i32:0
+test_f32_ne_8() => i32:0
+test_f32_ne_9() => i32:0
+test_f32_ne_10() => i32:1
+test_f32_lt_1() => i32:0
+test_f32_lt_2() => i32:1
+test_f32_lt_3() => i32:0
+test_f32_lt_4() => i32:1
+test_f32_lt_5() => i32:0
+test_f32_lt_6() => i32:0
+test_f32_lt_7() => i32:1
+test_f32_lt_8() => i32:0
+test_f32_lt_9() => i32:0
+test_f32_lt_10() => i32:0
+test_f32_lt_11() => i32:0
+test_f32_le_1() => i32:1
+test_f32_le_2() => i32:1
+test_f32_le_3() => i32:0
+test_f32_le_4() => i32:1
+test_f32_le_5() => i32:0
+test_f32_le_6() => i32:1
+test_f32_le_7() => i32:1
+test_f32_le_8() => i32:0
+test_f32_le_9() => i32:1
+test_f32_le_10() => i32:0
+test_f32_le_11() => i32:0
+test_f32_gt_1() => i32:0
+test_f32_gt_2() => i32:0
+test_f32_gt_3() => i32:1
+test_f32_gt_4() => i32:0
+test_f32_gt_5() => i32:1
+test_f32_gt_6() => i32:0
+test_f32_gt_7() => i32:0
+test_f32_gt_8() => i32:1
+test_f32_gt_9() => i32:0
+test_f32_gt_10() => i32:0
+test_f32_gt_11() => i32:0
+test_f32_ge_1() => i32:1
+test_f32_ge_2() => i32:0
+test_f32_ge_3() => i32:1
+test_f32_ge_4() => i32:0
+test_f32_ge_5() => i32:1
+test_f32_ge_6() => i32:1
+test_f32_ge_7() => i32:0
+test_f32_ge_8() => i32:1
+test_f32_ge_9() => i32:1
+test_f32_ge_10() => i32:0
+test_f32_ge_11() => i32:0
+;;; STDOUT ;;)


### PR DESCRIPTION
This PR implements the following opcodes for performing f32 comparisons:

- `f32.eq`
- `f32.ne`
- `f32.lt`
- `f32.le`
- `f32.gt`
- `f32.ge`