### PR TITLE
Implement local variable and parameter related opcodes

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -222,6 +222,26 @@ void FunctionBuilder::DropKeep(TR::IlBuilder* b, uint32_t drop_count, uint8_t ke
   b->StoreAt(stack_top_addr, new_stack_top);
 }
 
+/**
+ * @brief Generate load from the interpreter stack by an index
+ *
+ * The generate code should be equivalent to:
+ *
+ * return &value_stack_[value_stack_top_ - depth];
+ */
+TR::IlValue* FunctionBuilder::Pick(TR::IlBuilder* b, Index depth) {
+  auto pInt32 = typeDictionary()->PointerTo(Int32);
+  auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
+  auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
+
+  auto* offset = b->Sub(
+                 b->    LoadAt(pInt32, stack_top_addr),
+                 b->    ConstInt32(depth));
+  return b->IndexAt(pValueType_,
+                    stack_base_addr,
+                    offset);
+}
+
 template <>
 const char* FunctionBuilder::TypeFieldName<int32_t>() const {
   return "i32";

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -535,6 +535,13 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       DropKeep(b, 1, 0);
       break;
 
+    case Opcode::InterpDropKeep: {
+      uint32_t drop_count = ReadU32(&pc);
+      uint8_t keep_count = *pc++;
+      DropKeep(b, drop_count, keep_count);
+      break;
+    }
+
     case Opcode::Nop:
       break;
 

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -56,6 +56,20 @@ class FunctionBuilder : public TR::MethodBuilder {
    */
   void DropKeep(TR::IlBuilder* b, uint32_t drop_count, uint8_t keep_count);
 
+  /**
+   * @brief Generate load of pointer to a vlue on the interpreter stack by an index
+   * @param b is the builder object used to generate the code
+   * @param depth is the index from the top of the stack
+   * @return and IlValue representing a pointer to the value on the stack
+   *
+   * JitBuilder does not currently represent unions as value types. This a problem
+   * for this function because it cannot simply return an IlValue representing
+   * the union. As workaround, it will generate a load of the *base address* of
+   * the union, instead of loading the union directly. This behaviour differs
+   * from `Thread::Pick()` and users must take this into account.
+   */
+  TR::IlValue* Pick(TR::IlBuilder* b, Index depth);
+
  private:
   struct BytecodeWorkItem {
     TR::BytecodeBuilder* builder;

--- a/test/jit/alloca_dropkeep.txt
+++ b/test/jit/alloca_dropkeep.txt
@@ -1,0 +1,424 @@
+;;; TOOL: run-interp-jit
+(module
+  (func (export "test_alloca_i32")
+    call $alloca_i32)
+
+  (func $alloca_i32 (local i32))
+
+  (func (export "test_alloca_i64")
+    call $alloca_i64)
+
+  (func $alloca_i64 (local i64))
+
+  (func (export "test_alloca_f32")
+    call $alloca_f32)
+
+  (func $alloca_f32 (local f32))
+
+  (func (export "test_alloca_f64")
+    call $alloca_f64)
+
+  (func $alloca_f64 (local f64))
+
+  (func (export "test_alloca_with_dropkeep_i32") (result i32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i32
+    return)
+
+  (func $alloca_with_dropkeep_i32 (result i32) (local i32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i64") (result i64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i64
+    return)
+
+  (func $alloca_with_dropkeep_i64 (result i64) (local i64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f32") (result f32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f32
+    return)
+
+  (func $alloca_with_dropkeep_f32 (result f32) (local f32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f64") (result f64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f64
+    return)
+
+  (func $alloca_with_dropkeep_f64 (result f64) (local f64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i32_i32_0") (result i32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i32_i32_0
+    return)
+
+  (func $alloca_with_dropkeep_i32_i32_0 (result i32) (local i32) (local i32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i64_i32_0") (result i64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i64_i32_0
+    return)
+
+  (func $alloca_with_dropkeep_i64_i32_0 (result i64) (local i64) (local i32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f32_i32_0") (result f32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f32_i32_0
+    return)
+
+  (func $alloca_with_dropkeep_f32_i32_0 (result f32) (local f32) (local i32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f64_i32_0") (result f64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f64_i32_0
+    return)
+
+  (func $alloca_with_dropkeep_f64_i32_0 (result f64) (local f64) (local i32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i32_i32_1") (result i32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i32_i32_1
+    return)
+
+  (func $alloca_with_dropkeep_i32_i32_1 (result i32) (local i32) (local i32)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i64_i32_1") (result i32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i64_i32_1
+    return)
+
+  (func $alloca_with_dropkeep_i64_i32_1 (result i32) (local i64) (local i32)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f32_i32_1") (result i32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f32_i32_1
+    return)
+
+  (func $alloca_with_dropkeep_f32_i32_1 (result i32) (local f32) (local i32)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f64_i32_1") (result i32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f64_i32_1
+    return)
+
+  (func $alloca_with_dropkeep_f64_i32_1 (result i32) (local f64) (local i32)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i32_i64_0") (result i32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i32_i64_0
+    return)
+
+  (func $alloca_with_dropkeep_i32_i64_0 (result i32) (local i32) (local i64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i64_i64_0") (result i64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i64_i64_0
+    return)
+
+  (func $alloca_with_dropkeep_i64_i64_0 (result i64) (local i64) (local i64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f32_i64_0") (result f32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f32_i64_0
+    return)
+
+  (func $alloca_with_dropkeep_f32_i64_0 (result f32) (local f32) (local i64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f64_i64_0") (result f64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f64_i64_0
+    return)
+
+  (func $alloca_with_dropkeep_f64_i64_0 (result f64) (local f64) (local i64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i32_i64_1") (result i64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i32_i64_1
+    return)
+
+  (func $alloca_with_dropkeep_i32_i64_1 (result i64) (local i32) (local i64)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i64_i64_1") (result i64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i64_i64_1
+    return)
+
+  (func $alloca_with_dropkeep_i64_i64_1 (result i64) (local i64) (local i64)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f32_i64_1") (result i64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f32_i64_1
+    return)
+
+  (func $alloca_with_dropkeep_f32_i64_1 (result i64) (local f32) (local i64)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f64_i64_1") (result i64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f64_i64_1
+    return)
+
+  (func $alloca_with_dropkeep_f64_i64_1 (result i64) (local f64) (local i64)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i32_f32_0") (result i32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i32_f32_0
+    return)
+
+  (func $alloca_with_dropkeep_i32_f32_0 (result i32) (local i32) (local f32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i64_f32_0") (result i64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i64_f32_0
+    return)
+
+  (func $alloca_with_dropkeep_i64_f32_0 (result i64) (local i64) (local f32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f32_f32_0") (result f32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f32_f32_0
+    return)
+
+  (func $alloca_with_dropkeep_f32_f32_0 (result f32) (local f32) (local f32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f64_f32_0") (result f64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f64_f32_0
+    return)
+
+  (func $alloca_with_dropkeep_f64_f32_0 (result f64) (local f64) (local f32)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i32_f32_1") (result f32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i32_f32_1
+    return)
+
+  (func $alloca_with_dropkeep_i32_f32_1 (result f32) (local i32) (local f32)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i64_f32_1") (result f32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i64_f32_1
+    return)
+
+  (func $alloca_with_dropkeep_i64_f32_1 (result f32) (local i64) (local f32)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f32_f32_1") (result f32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f32_f32_1
+    return)
+
+  (func $alloca_with_dropkeep_f32_f32_1 (result f32) (local f32) (local f32)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f64_f32_1") (result f32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f64_f32_1
+    return)
+
+  (func $alloca_with_dropkeep_f64_f32_1 (result f32) (local f64) (local f32)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i32_f64_0") (result i32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i32_f64_0
+    return)
+
+  (func $alloca_with_dropkeep_i32_f64_0 (result i32) (local i32) (local f64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i64_f64_0") (result i64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i64_f64_0
+    return)
+
+  (func $alloca_with_dropkeep_i64_f64_0 (result i64) (local i64) (local f64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f32_f64_0") (result f32)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f32_f64_0
+    return)
+
+  (func $alloca_with_dropkeep_f32_f64_0 (result f32) (local f32) (local f64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f64_f64_0") (result f64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f64_f64_0
+    return)
+
+  (func $alloca_with_dropkeep_f64_f64_0 (result f64) (local f64) (local f64)
+    get_local 0
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i32_f64_1") (result f64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i32_f64_1
+    return)
+
+  (func $alloca_with_dropkeep_i32_f64_1 (result f64) (local i32) (local f64)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_i64_f64_1") (result f64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_i64_f64_1
+    return)
+
+  (func $alloca_with_dropkeep_i64_f64_1 (result f64) (local i64) (local f64)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f32_f64_1") (result f64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f32_f64_1
+    return)
+
+  (func $alloca_with_dropkeep_f32_f64_1 (result f64) (local f32) (local f64)
+    get_local 1
+    return)
+
+  (func (export "test_alloca_with_dropkeep_f64_f64_1") (result f64)
+    i32.const 3
+    drop
+    call $alloca_with_dropkeep_f64_f64_1
+    return)
+
+  (func $alloca_with_dropkeep_f64_f64_1 (result f64) (local f64) (local f64)
+    get_local 1
+    return)
+)
+(;; STDOUT ;;;
+test_alloca_i32() =>
+test_alloca_i64() =>
+test_alloca_f32() =>
+test_alloca_f64() =>
+test_alloca_with_dropkeep_i32() => i32:0
+test_alloca_with_dropkeep_i64() => i64:0
+test_alloca_with_dropkeep_f32() => f32:0.000000
+test_alloca_with_dropkeep_f64() => f64:0.000000
+test_alloca_with_dropkeep_i32_i32_0() => i32:0
+test_alloca_with_dropkeep_i64_i32_0() => i64:0
+test_alloca_with_dropkeep_f32_i32_0() => f32:0.000000
+test_alloca_with_dropkeep_f64_i32_0() => f64:0.000000
+test_alloca_with_dropkeep_i32_i32_1() => i32:0
+test_alloca_with_dropkeep_i64_i32_1() => i32:0
+test_alloca_with_dropkeep_f32_i32_1() => i32:0
+test_alloca_with_dropkeep_f64_i32_1() => i32:0
+test_alloca_with_dropkeep_i32_i64_0() => i32:0
+test_alloca_with_dropkeep_i64_i64_0() => i64:0
+test_alloca_with_dropkeep_f32_i64_0() => f32:0.000000
+test_alloca_with_dropkeep_f64_i64_0() => f64:0.000000
+test_alloca_with_dropkeep_i32_i64_1() => i64:0
+test_alloca_with_dropkeep_i64_i64_1() => i64:0
+test_alloca_with_dropkeep_f32_i64_1() => i64:0
+test_alloca_with_dropkeep_f64_i64_1() => i64:0
+test_alloca_with_dropkeep_i32_f32_0() => i32:0
+test_alloca_with_dropkeep_i64_f32_0() => i64:0
+test_alloca_with_dropkeep_f32_f32_0() => f32:0.000000
+test_alloca_with_dropkeep_f64_f32_0() => f64:0.000000
+test_alloca_with_dropkeep_i32_f32_1() => f32:0.000000
+test_alloca_with_dropkeep_i64_f32_1() => f32:0.000000
+test_alloca_with_dropkeep_f32_f32_1() => f32:0.000000
+test_alloca_with_dropkeep_f64_f32_1() => f32:0.000000
+test_alloca_with_dropkeep_i32_f64_0() => i32:0
+test_alloca_with_dropkeep_i64_f64_0() => i64:0
+test_alloca_with_dropkeep_f32_f64_0() => f32:0.000000
+test_alloca_with_dropkeep_f64_f64_0() => f64:0.000000
+test_alloca_with_dropkeep_i32_f64_1() => f64:0.000000
+test_alloca_with_dropkeep_i64_f64_1() => f64:0.000000
+test_alloca_with_dropkeep_f32_f64_1() => f64:0.000000
+test_alloca_with_dropkeep_f64_f64_1() => f64:0.000000
+;;; STDOUT ;;)

--- a/test/jit/get_set_tee_local.txt
+++ b/test/jit/get_set_tee_local.txt
@@ -1,0 +1,696 @@
+;;; TOOL: run-interp-jit
+(module
+  (func $get_local_i32 (param i32) (result i32)
+    get_local 0
+    return)
+
+  (func (export "test_get_local_i32_1") (result i32)
+    i32.const 0
+    call $get_local_i32)
+
+  (func (export "test_get_local_i32_2") (result i32)
+    i32.const 1
+    call $get_local_i32)
+
+  (func (export "test_get_local_i32_3") (result i32)
+    i32.const 42
+    call $get_local_i32)
+
+  (func (export "test_get_local_i32_4") (result i32)
+    i32.const 0xffffffff
+    call $get_local_i32)
+
+  (func $get_local_i64 (param i64) (result i64)
+    get_local 0
+    return)
+
+  (func (export "test_get_local_i64_1") (result i64)
+    i64.const 0
+    call $get_local_i64)
+
+  (func (export "test_get_local_i64_2") (result i64)
+    i64.const 1
+    call $get_local_i64)
+
+  (func (export "test_get_local_i64_3") (result i64)
+    i64.const 42
+    call $get_local_i64)
+
+  (func (export "test_get_local_i64_4") (result i64)
+    i64.const 0xffffffffffffffff
+    call $get_local_i64)
+
+  (func $get_local_f32 (param f32) (result f32)
+    get_local 0
+    return)
+
+  (func (export "test_get_local_f32_1") (result f32)
+    f32.const 0.0
+    call $get_local_f32)
+
+  (func (export "test_get_local_f32_2") (result f32)
+    f32.const -0.0
+    call $get_local_f32)
+
+  (func (export "test_get_local_f32_3") (result f32)
+    f32.const 1.0
+    call $get_local_f32)
+
+  (func (export "test_get_local_f32_4") (result f32)
+    f32.const -1.0
+    call $get_local_f32)
+
+  (func (export "test_get_local_f32_5") (result f32)
+    f32.const 4.2
+    call $get_local_f32)
+
+  (func (export "test_get_local_f32_6") (result f32)
+    f32.const -4.2
+    call $get_local_f32)
+
+  (func (export "test_get_local_f32_7") (result f32)
+    f32.const inf
+    call $get_local_f32)
+
+  (func (export "test_get_local_f32_8") (result f32)
+    f32.const -inf
+    call $get_local_f32)
+
+  (func (export "test_get_local_f32_9") (result f32)
+    f32.const nan
+    call $get_local_f32)
+
+  (func $get_local_f64 (param f64) (result f64)
+    get_local 0
+    return)
+
+  (func (export "test_get_local_f64_1") (result f64)
+    f64.const 0.0
+    call $get_local_f64)
+
+  (func (export "test_get_local_f64_2") (result f64)
+    f64.const -0.0
+    call $get_local_f64)
+
+  (func (export "test_get_local_f64_3") (result f64)
+    f64.const 1.0
+    call $get_local_f64)
+
+  (func (export "test_get_local_f64_4") (result f64)
+    f64.const -1.0
+    call $get_local_f64)
+
+  (func (export "test_get_local_f64_5") (result f64)
+    f64.const 4.2
+    call $get_local_f64)
+
+  (func (export "test_get_local_f64_6") (result f64)
+    f64.const -4.2
+    call $get_local_f64)
+
+  (func (export "test_get_local_f64_7") (result f64)
+    f64.const inf
+    call $get_local_f64)
+
+  (func (export "test_get_local_f64_8") (result f64)
+    f64.const -inf
+    call $get_local_f64)
+
+  (func (export "test_get_local_f64_9") (result f64)
+    f64.const nan
+    call $get_local_f64)
+
+  (func $set_local_i32_1 (result i32) (local i32)
+    i32.const 0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_i32_1") (result i32)
+    call $set_local_i32_1)
+
+  (func $set_local_i32_2 (result i32) (local i32)
+    i32.const 1
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_i32_2") (result i32)
+    call $set_local_i32_2)
+
+  (func $set_local_i32_3 (result i32) (local i32)
+    i32.const 42
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_i32_3") (result i32)
+    call $set_local_i32_3)
+
+  (func $set_local_i32_4 (result i32) (local i32)
+    i32.const 0xffffffff
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_i32_4") (result i32)
+    call $set_local_i32_4)
+
+  (func $set_local_i64_1 (result i64) (local i64)
+    i64.const 0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_i64_1") (result i64)
+    call $set_local_i64_1)
+
+  (func $set_local_i64_2 (result i64) (local i64)
+    i64.const 1
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_i64_2") (result i64)
+    call $set_local_i64_2)
+
+  (func $set_local_i64_3 (result i64) (local i64)
+    i64.const 42
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_i64_3") (result i64)
+    call $set_local_i64_3)
+
+  (func $set_local_i64_4 (result i64) (local i64)
+    i64.const 0xffffffffffffffff
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_i64_4") (result i64)
+    call $set_local_i64_4)
+
+  (func $set_local_f32_1 (result f32) (local f32)
+    f32.const 0.0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f32_1") (result f32)
+    call $set_local_f32_1)
+
+  (func $set_local_f32_2 (result f32) (local f32)
+    f32.const -0.0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f32_2") (result f32)
+    call $set_local_f32_2)
+
+  (func $set_local_f32_3 (result f32) (local f32)
+    f32.const 1.0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f32_3") (result f32)
+    call $set_local_f32_3)
+
+  (func $set_local_f32_4 (result f32) (local f32)
+    f32.const -1.0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f32_4") (result f32)
+    call $set_local_f32_4)
+
+  (func $set_local_f32_5 (result f32) (local f32)
+    f32.const 4.2
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f32_5") (result f32)
+    call $set_local_f32_5)
+
+  (func $set_local_f32_6 (result f32) (local f32)
+    f32.const -4.2
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f32_6") (result f32)
+    call $set_local_f32_6)
+
+  (func $set_local_f32_7 (result f32) (local f32)
+    f32.const inf
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f32_7") (result f32)
+    call $set_local_f32_7)
+
+  (func $set_local_f32_8 (result f32) (local f32)
+    f32.const -inf
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f32_8") (result f32)
+    call $set_local_f32_8)
+
+  (func $set_local_f32_9 (result f32) (local f32)
+    f32.const nan
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f32_9") (result f32)
+    call $set_local_f32_9)
+
+  (func $set_local_f64_1 (result f64) (local f64)
+    f64.const 0.0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f64_1") (result f64)
+    call $set_local_f64_1)
+
+  (func $set_local_f64_2 (result f64) (local f64)
+    f64.const -0.0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f64_2") (result f64)
+    call $set_local_f64_2)
+
+  (func $set_local_f64_3 (result f64) (local f64)
+    f64.const 1.0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f64_3") (result f64)
+    call $set_local_f64_3)
+
+  (func $set_local_f64_4 (result f64) (local f64)
+    f64.const -1.0
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f64_4") (result f64)
+    call $set_local_f64_4)
+
+  (func $set_local_f64_5 (result f64) (local f64)
+    f64.const 4.2
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f64_5") (result f64)
+    call $set_local_f64_5)
+
+  (func $set_local_f64_6 (result f64) (local f64)
+    f64.const -4.2
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f64_6") (result f64)
+    call $set_local_f64_6)
+
+  (func $set_local_f64_7 (result f64) (local f64)
+    f64.const inf
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f64_7") (result f64)
+    call $set_local_f64_7)
+
+  (func $set_local_f64_8 (result f64) (local f64)
+    f64.const -inf
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f64_8") (result f64)
+    call $set_local_f64_8)
+
+  (func $set_local_f64_9 (result f64) (local f64)
+    f64.const nan
+    set_local 0
+    get_local 0
+    return)
+
+  (func (export "test_set_local_f64_9") (result f64)
+    call $set_local_f64_9)
+
+  (func $tee_local_i32_1 (result i32) (local i32)
+    i32.const 0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_i32_1") (result i32)
+    call $tee_local_i32_1)
+
+  (func $tee_local_i32_2 (result i32) (local i32)
+    i32.const 1
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_i32_2") (result i32)
+    call $tee_local_i32_2)
+
+  (func $tee_local_i32_3 (result i32) (local i32)
+    i32.const 42
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_i32_3") (result i32)
+    call $tee_local_i32_3)
+
+  (func $tee_local_i32_4 (result i32) (local i32)
+    i32.const 0xffffffff
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_i32_4") (result i32)
+    call $tee_local_i32_4)
+
+  (func $tee_local_i64_1 (result i64) (local i64)
+    i64.const 0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_i64_1") (result i64)
+    call $tee_local_i64_1)
+
+  (func $tee_local_i64_2 (result i64) (local i64)
+    i64.const 1
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_i64_2") (result i64)
+    call $tee_local_i64_2)
+
+  (func $tee_local_i64_3 (result i64) (local i64)
+    i64.const 42
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_i64_3") (result i64)
+    call $tee_local_i64_3)
+
+  (func $tee_local_i64_4 (result i64) (local i64)
+    i64.const 0xffffffffffffffff
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_i64_4") (result i64)
+    call $tee_local_i64_4)
+
+  (func $tee_local_f32_1 (result f32) (local f32)
+    f32.const 0.0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f32_1") (result f32)
+    call $tee_local_f32_1)
+
+  (func $tee_local_f32_2 (result f32) (local f32)
+    f32.const -0.0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f32_2") (result f32)
+    call $tee_local_f32_2)
+
+  (func $tee_local_f32_3 (result f32) (local f32)
+    f32.const 1.0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f32_3") (result f32)
+    call $tee_local_f32_3)
+
+  (func $tee_local_f32_4 (result f32) (local f32)
+    f32.const -1.0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f32_4") (result f32)
+    call $tee_local_f32_4)
+
+  (func $tee_local_f32_5 (result f32) (local f32)
+    f32.const 4.2
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f32_5") (result f32)
+    call $tee_local_f32_5)
+
+  (func $tee_local_f32_6 (result f32) (local f32)
+    f32.const -4.2
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f32_6") (result f32)
+    call $tee_local_f32_6)
+
+  (func $tee_local_f32_7 (result f32) (local f32)
+    f32.const inf
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f32_7") (result f32)
+    call $tee_local_f32_7)
+
+  (func $tee_local_f32_8 (result f32) (local f32)
+    f32.const -inf
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f32_8") (result f32)
+    call $tee_local_f32_8)
+
+  (func $tee_local_f32_9 (result f32) (local f32)
+    f32.const nan
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f32_9") (result f32)
+    call $tee_local_f32_9)
+
+  (func $tee_local_f64_1 (result f64) (local f64)
+    f64.const 0.0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f64_1") (result f64)
+    call $tee_local_f64_1)
+
+  (func $tee_local_f64_2 (result f64) (local f64)
+    f64.const -0.0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f64_2") (result f64)
+    call $tee_local_f64_2)
+
+  (func $tee_local_f64_3 (result f64) (local f64)
+    f64.const 1.0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f64_3") (result f64)
+    call $tee_local_f64_3)
+
+  (func $tee_local_f64_4 (result f64) (local f64)
+    f64.const -1.0
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f64_4") (result f64)
+    call $tee_local_f64_4)
+
+  (func $tee_local_f64_5 (result f64) (local f64)
+    f64.const 4.2
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f64_5") (result f64)
+    call $tee_local_f64_5)
+
+  (func $tee_local_f64_6 (result f64) (local f64)
+    f64.const -4.2
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f64_6") (result f64)
+    call $tee_local_f64_6)
+
+  (func $tee_local_f64_7 (result f64) (local f64)
+    f64.const inf
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f64_7") (result f64)
+    call $tee_local_f64_7)
+
+  (func $tee_local_f64_8 (result f64) (local f64)
+    f64.const -inf
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f64_8") (result f64)
+    call $tee_local_f64_8)
+
+  (func $tee_local_f64_9 (result f64) (local f64)
+    f64.const nan
+    tee_local 0
+    drop
+    get_local 0
+    return)
+
+  (func (export "test_tee_local_f64_9") (result f64)
+    call $tee_local_f64_9)
+)
+(;; STDOUT ;;;
+test_get_local_i32_1() => i32:0
+test_get_local_i32_2() => i32:1
+test_get_local_i32_3() => i32:42
+test_get_local_i32_4() => i32:4294967295
+test_get_local_i64_1() => i64:0
+test_get_local_i64_2() => i64:1
+test_get_local_i64_3() => i64:42
+test_get_local_i64_4() => i64:18446744073709551615
+test_get_local_f32_1() => f32:0.000000
+test_get_local_f32_2() => f32:-0.000000
+test_get_local_f32_3() => f32:1.000000
+test_get_local_f32_4() => f32:-1.000000
+test_get_local_f32_5() => f32:4.200000
+test_get_local_f32_6() => f32:-4.200000
+test_get_local_f32_7() => f32:inf
+test_get_local_f32_8() => f32:-inf
+test_get_local_f32_9() => f32:nan
+test_get_local_f64_1() => f64:0.000000
+test_get_local_f64_2() => f64:-0.000000
+test_get_local_f64_3() => f64:1.000000
+test_get_local_f64_4() => f64:-1.000000
+test_get_local_f64_5() => f64:4.200000
+test_get_local_f64_6() => f64:-4.200000
+test_get_local_f64_7() => f64:inf
+test_get_local_f64_8() => f64:-inf
+test_get_local_f64_9() => f64:nan
+test_set_local_i32_1() => i32:0
+test_set_local_i32_2() => i32:1
+test_set_local_i32_3() => i32:42
+test_set_local_i32_4() => i32:4294967295
+test_set_local_i64_1() => i64:0
+test_set_local_i64_2() => i64:1
+test_set_local_i64_3() => i64:42
+test_set_local_i64_4() => i64:18446744073709551615
+test_set_local_f32_1() => f32:0.000000
+test_set_local_f32_2() => f32:-0.000000
+test_set_local_f32_3() => f32:1.000000
+test_set_local_f32_4() => f32:-1.000000
+test_set_local_f32_5() => f32:4.200000
+test_set_local_f32_6() => f32:-4.200000
+test_set_local_f32_7() => f32:inf
+test_set_local_f32_8() => f32:-inf
+test_set_local_f32_9() => f32:nan
+test_set_local_f64_1() => f64:0.000000
+test_set_local_f64_2() => f64:-0.000000
+test_set_local_f64_3() => f64:1.000000
+test_set_local_f64_4() => f64:-1.000000
+test_set_local_f64_5() => f64:4.200000
+test_set_local_f64_6() => f64:-4.200000
+test_set_local_f64_7() => f64:inf
+test_set_local_f64_8() => f64:-inf
+test_set_local_f64_9() => f64:nan
+test_tee_local_i32_1() => i32:0
+test_tee_local_i32_2() => i32:1
+test_tee_local_i32_3() => i32:42
+test_tee_local_i32_4() => i32:4294967295
+test_tee_local_i64_1() => i64:0
+test_tee_local_i64_2() => i64:1
+test_tee_local_i64_3() => i64:42
+test_tee_local_i64_4() => i64:18446744073709551615
+test_tee_local_f32_1() => f32:0.000000
+test_tee_local_f32_2() => f32:-0.000000
+test_tee_local_f32_3() => f32:1.000000
+test_tee_local_f32_4() => f32:-1.000000
+test_tee_local_f32_5() => f32:4.200000
+test_tee_local_f32_6() => f32:-4.200000
+test_tee_local_f32_7() => f32:inf
+test_tee_local_f32_8() => f32:-inf
+test_tee_local_f32_9() => f32:nan
+test_tee_local_f64_1() => f64:0.000000
+test_tee_local_f64_2() => f64:-0.000000
+test_tee_local_f64_3() => f64:1.000000
+test_tee_local_f64_4() => f64:-1.000000
+test_tee_local_f64_5() => f64:4.200000
+test_tee_local_f64_6() => f64:-4.200000
+test_tee_local_f64_7() => f64:inf
+test_tee_local_f64_8() => f64:-inf
+test_tee_local_f64_9() => f64:nan
+;;; STDOUT ;;)


### PR DESCRIPTION
This changeset implements the following opcodes:

- `get_local`
- `set_local`
- `tee_local`
- `alloca`
- `drop_keep`

Closes #40 
