### PR TITLE
Implement counted compilation

### DIFF
--- a/src/binary-reader-interp.cc
+++ b/src/binary-reader-interp.cc
@@ -1054,6 +1054,9 @@ wabt::Result BinaryReaderInterp::BeginFunctionBody(Index index) {
   func->local_decl_count = 0;
   func->local_count = 0;
 
+  /* wasmjit-omr: emit JIT metadata now that func->offset is known */
+  env_->AddJitMetadata(func);
+
   current_func_ = func;
   depth_fixups_.clear();
   label_stack_.clear();

--- a/src/interp.cc
+++ b/src/interp.cc
@@ -1334,10 +1334,14 @@ Result Thread::Run(int num_instructions) {
           if (meta_it != env_->jit_meta_.end()) {
             auto* meta = &meta_it->second;
             if (!meta->tried_jit) {
-              meta->jit_fn = jit::compile(this, meta->wasm_fn);
-              meta->tried_jit = true;
+              meta->num_calls++;
 
-              TRAP_IF(env_->trap_on_failed_comp && meta->jit_fn == nullptr, FailedJITCompilation);
+              if (meta->num_calls >= env_->jit_threshold) {
+                meta->jit_fn = jit::compile(this, meta->wasm_fn);
+                meta->tried_jit = true;
+
+                TRAP_IF(env_->trap_on_failed_comp && meta->jit_fn == nullptr, FailedJITCompilation);
+              }
             }
 
             if (meta->jit_fn) {

--- a/src/interp.h
+++ b/src/interp.h
@@ -353,6 +353,7 @@ class Environment {
 
   bool enable_jit = true;
   bool trap_on_failed_comp = false;
+  uint32_t jit_threshold = 1;
 
   Environment();
 
@@ -469,6 +470,7 @@ class Environment {
 
   struct JitMeta {
     DefinedFunc* wasm_fn;
+    uint32_t num_calls = 0;
 
     bool tried_jit = false;
     JITedFunction jit_fn = nullptr;

--- a/src/interp.h
+++ b/src/interp.h
@@ -414,6 +414,11 @@ class Environment {
     return funcs_.back().get();
   }
 
+  void AddJitMetadata(DefinedFunc* fn) {
+    assert(fn->offset != kInvalidIstreamOffset);
+    this->jit_meta_.insert({ fn->offset, JitMeta(fn) });
+  }
+
   template <typename... Args>
   Global* EmplaceBackGlobal(Args&&... args) {
     globals_.emplace_back(std::forward<Args>(args)...);
@@ -462,6 +467,15 @@ class Environment {
   friend class Thread;
   using JITedFunction = wabt::interp::Result (*)();
 
+  struct JitMeta {
+    DefinedFunc* wasm_fn;
+
+    bool tried_jit = false;
+    JITedFunction jit_fn = nullptr;
+
+    JitMeta(DefinedFunc* wasm_fn) : wasm_fn(wasm_fn) {}
+  };
+
   std::vector<std::unique_ptr<Module>> modules_;
   std::vector<FuncSignature> sigs_;
   std::vector<std::unique_ptr<Func>> funcs_;
@@ -473,7 +487,7 @@ class Environment {
   BindingHash registered_module_bindings_;
 
   jit::JitEnvironment jit_env_;
-  std::unordered_map<IstreamOffset, JITedFunction> jit_compiled_functions_;
+  std::unordered_map<IstreamOffset, JitMeta> jit_meta_;
 };
 
 class Thread {

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -76,10 +76,10 @@ inline Opcode ReadOpcodeAt(const uint8_t* pc) {
   return ReadOpcode(&pc);
 }
 
-FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::IstreamOffset const offset, TypeDictionary* types)
+FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn, TypeDictionary* types)
     : TR::MethodBuilder(types),
       thread_(thread),
-      offset_(offset),
+      fn_(fn),
       valueType_(types->LookupUnion("Value")),
       pValueType_(types->PointerTo(types->LookupUnion("Value"))) {
   DefineLine(__LINE__);
@@ -106,8 +106,8 @@ bool FunctionBuilder::buildIL() {
 
   const uint8_t* istream = thread_->GetIstream();
 
-  workItems_.emplace_back(OrphanBytecodeBuilder(0, const_cast<char*>(ReadOpcodeAt(&istream[offset_]).GetName())),
-                          &istream[offset_]);
+  workItems_.emplace_back(OrphanBytecodeBuilder(0, const_cast<char*>(ReadOpcodeAt(&istream[fn_->offset]).GetName())),
+                          &istream[fn_->offset]);
   AppendBuilder(workItems_[0].builder);
 
   int32_t next_index;

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -29,7 +29,7 @@ namespace jit {
 
 class FunctionBuilder : public TR::MethodBuilder {
  public:
-  FunctionBuilder(interp::Thread* thread, interp::IstreamOffset const offset, TypeDictionary* types);
+  FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn, TypeDictionary* types);
   bool buildIL() override;
 
   /**
@@ -104,7 +104,7 @@ class FunctionBuilder : public TR::MethodBuilder {
   std::vector<BytecodeWorkItem> workItems_;
 
   interp::Thread* thread_;
-  interp::IstreamOffset const offset_;
+  interp::DefinedFunc* fn_;
 
   TR::IlType* const valueType_;
   TR::IlType* const pValueType_;

--- a/src/jit/wabtjit.cc
+++ b/src/jit/wabtjit.cc
@@ -20,9 +20,12 @@
 
 #include "Jit.hpp"
 
-wabt::jit::JITedFunction wabt::jit::compile(wabt::interp::Thread* thread, wabt::interp::IstreamOffset offset) {
+namespace wabt {
+namespace jit {
+
+JITedFunction compile(interp::Thread* thread, interp::DefinedFunc* fn) {
   TypeDictionary types;
-  FunctionBuilder builder{thread, offset, &types};
+  FunctionBuilder builder(thread, fn, &types);
   uint8_t* function = nullptr;
 
   if (compileMethodBuilder(&builder, &function) == 0) {
@@ -30,4 +33,7 @@ wabt::jit::JITedFunction wabt::jit::compile(wabt::interp::Thread* thread, wabt::
   } else {
     return nullptr;
   }
+}
+
+}
 }

--- a/src/jit/wabtjit.h
+++ b/src/jit/wabtjit.h
@@ -23,9 +23,9 @@
 namespace wabt {
 namespace jit {
 
-using JITedFunction = wabt::interp::Result (*)();
+using JITedFunction = interp::Result (*)();
 
-JITedFunction compile(wabt::interp::Thread* thread, wabt::interp::IstreamOffset offset);
+JITedFunction compile(interp::Thread* thread, interp::DefinedFunc* fn);
 
 }
 }

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -50,6 +50,7 @@ static bool s_run_all_exports;
 static bool s_host_print;
 static bool s_disable_jit;
 static bool s_trap_on_failed_comp;
+static uint32_t s_jit_threshold = 1;
 static Features s_features;
 
 static std::unique_ptr<FileStream> s_log_stream;
@@ -116,6 +117,12 @@ static void ParseOptions(int argc, char** argv) {
   parser.AddOption("trap-on-failed-comp",
                    "Trap if a JIT compilation fails",
                    []() { s_trap_on_failed_comp = true; });
+  parser.AddOption('\0', "jit-threshold", "THRESHOLD",
+                   "Number of calls after which to JIT compile a function",
+                   [](const std::string& argument) {
+                     // TODO(thomasbc): validate
+                     s_jit_threshold = atoi(argument.c_str());
+                   });
 
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                      [](const char* argument) { s_infile = argument; });
@@ -239,6 +246,8 @@ static void InitEnvironment(Environment* env) {
   if (s_trap_on_failed_comp) {
     env->trap_on_failed_comp = true;
   }
+
+  env->jit_threshold = s_jit_threshold;
 }
 
 static wabt::Result ReadAndRunModule(const char* module_filename) {

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -33,4 +33,5 @@ options:
       --host-print                            Include an importable function named "host.print" for printing to stdout
       --disable-jit                           Prevent just in time compilation
       --trap-on-failed-comp                   Trap if a JIT compilation fails
+      --jit-threshold=THRESHOLD               Number of calls after which to JIT compile a function
 ;;; STDOUT ;;)


### PR DESCRIPTION
This PR introduces counted compilation into `libwabt` and adds a `--jit-threshold` argument to `wasm-interp` to control the number of calls after which JIT compilation should be attempted.