### PR TITLE
Implement i32 comparison opcodes

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -550,6 +550,72 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       });
       break;
 
+    case Opcode::I32Eqz:
+      EmitUnaryOp<int32_t, int>(b, [&](TR::IlValue* val) {
+        return b->EqualTo(val, b->ConstInt32(0));
+      });
+      break;
+
+    case Opcode::I32Eq:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->EqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32Ne:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->NotEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32LtS:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->LessThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32LtU:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->UnsignedLessThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32GtS:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->GreaterThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32GtU:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->UnsignedGreaterThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32LeS:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->LessOrEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32LeU:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->UnsignedLessOrEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32GeS:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->GreaterOrEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I32GeU:
+      EmitBinaryOp<int32_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->UnsignedGreaterOrEqualTo(lhs, rhs);
+      });
+      break;
+
     case Opcode::I64Add:
         EmitBinaryOp<int64_t>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
           return b->Add(lhs, rhs);

--- a/test/jit/i32_comparison.txt
+++ b/test/jit/i32_comparison.txt
@@ -1,0 +1,316 @@
+;;; TOOL: run-interp-jit
+(module
+  (func (export "test_i32_eqz_1") (result i32)
+    call $i32_eqz_1)
+
+  (func $i32_eqz_1 (result i32)
+    i32.const 0
+    i32.eqz)
+
+  (func (export "test_i32_eqz_2") (result i32)
+    call $i32_eqz_2)
+
+  (func $i32_eqz_2 (result i32)
+    i32.const -1
+    i32.eqz)
+
+  (func (export "test_i32_eqz_3") (result i32)
+    call $i32_eqz_3)
+
+  (func $i32_eqz_3 (result i32)
+    i32.const 1
+    i32.eqz)
+
+  (func (export "test_i32_eq_1") (result i32)
+    call $i32_eq_1)
+
+  (func $i32_eq_1 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.eq)
+
+  (func (export "test_i32_eq_2") (result i32)
+    call $i32_eq_2)
+
+  (func $i32_eq_2 (result i32)
+    i32.const 0xffffffff
+    i32.const 0
+    i32.eq)
+
+  (func (export "test_i32_eq_3") (result i32)
+    call $i32_eq_3)
+
+  (func $i32_eq_3 (result i32)
+    i32.const 0xffffffff
+    i32.const 0xffffffff
+    i32.eq)
+
+  (func (export "test_i32_eq_4") (result i32)
+    call $i32_eq_4)
+
+  (func $i32_eq_4 (result i32)
+    i32.const 33
+    i32.const 32
+    i32.eq)
+
+  (func (export "test_i32_ne_1") (result i32)
+    call $i32_ne_1)
+
+  (func $i32_ne_1 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.ne)
+
+  (func (export "test_i32_ne_2") (result i32)
+    call $i32_ne_2)
+
+  (func $i32_ne_2 (result i32)
+    i32.const 0xffffffff
+    i32.const 0
+    i32.ne)
+
+  (func (export "test_i32_ne_3") (result i32)
+    call $i32_ne_3)
+
+  (func $i32_ne_3 (result i32)
+    i32.const 0xffffffff
+    i32.const 0xffffffff
+    i32.ne)
+
+  (func (export "test_i32_ne_4") (result i32)
+    call $i32_ne_4)
+
+  (func $i32_ne_4 (result i32)
+    i32.const 33
+    i32.const 32
+    i32.ne)
+
+  (func (export "test_i32_lt_s_1") (result i32)
+    call $i32_lt_s_1)
+
+  (func $i32_lt_s_1 (result i32)
+    i32.const -1
+    i32.const 1
+    i32.lt_s)
+
+  (func (export "test_i32_lt_s_2") (result i32)
+    call $i32_lt_s_2)
+
+  (func $i32_lt_s_2 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.lt_s)
+
+  (func (export "test_i32_lt_s_3") (result i32)
+    call $i32_lt_s_3)
+
+  (func $i32_lt_s_3 (result i32)
+    i32.const 1
+    i32.const -1
+    i32.lt_s)
+
+  (func (export "test_i32_lt_u_1") (result i32)
+    call $i32_lt_u_1)
+
+  (func $i32_lt_u_1 (result i32)
+    i32.const 0xffffffff
+    i32.const 1
+    i32.lt_u)
+
+  (func (export "test_i32_lt_u_2") (result i32)
+    call $i32_lt_u_2)
+
+  (func $i32_lt_u_2 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.lt_u)
+
+  (func (export "test_i32_lt_u_3") (result i32)
+    call $i32_lt_u_3)
+
+  (func $i32_lt_u_3 (result i32)
+    i32.const 1
+    i32.const 0xffffffff
+    i32.lt_u)
+
+  (func (export "test_i32_gt_s_1") (result i32)
+    call $i32_gt_s_1)
+
+  (func $i32_gt_s_1 (result i32)
+    i32.const -1
+    i32.const 1
+    i32.gt_s)
+
+  (func (export "test_i32_gt_s_2") (result i32)
+    call $i32_gt_s_2)
+
+  (func $i32_gt_s_2 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.gt_s)
+
+  (func (export "test_i32_gt_s_3") (result i32)
+    call $i32_gt_s_3)
+
+  (func $i32_gt_s_3 (result i32)
+    i32.const 1
+    i32.const -1
+    i32.gt_s)
+
+  (func (export "test_i32_gt_u_1") (result i32)
+    call $i32_gt_u_1)
+
+  (func $i32_gt_u_1 (result i32)
+    i32.const 0xffffffff
+    i32.const 1
+    i32.gt_u)
+
+  (func (export "test_i32_gt_u_2") (result i32)
+    call $i32_gt_u_2)
+
+  (func $i32_gt_u_2 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.gt_u)
+
+  (func (export "test_i32_gt_u_3") (result i32)
+    call $i32_gt_u_3)
+
+  (func $i32_gt_u_3 (result i32)
+    i32.const 1
+    i32.const 0xffffffff
+    i32.gt_u)
+
+  (func (export "test_i32_le_s_1") (result i32)
+    call $i32_le_s_1)
+
+  (func $i32_le_s_1 (result i32)
+    i32.const -1
+    i32.const 1
+    i32.le_s)
+
+  (func (export "test_i32_le_s_2") (result i32)
+    call $i32_le_s_2)
+
+  (func $i32_le_s_2 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.le_s)
+
+  (func (export "test_i32_le_s_3") (result i32)
+    call $i32_le_s_3)
+
+  (func $i32_le_s_3 (result i32)
+    i32.const 1
+    i32.const -1
+    i32.le_s)
+
+  (func (export "test_i32_le_u_1") (result i32)
+    call $i32_le_u_1)
+
+  (func $i32_le_u_1 (result i32)
+    i32.const 0xffffffff
+    i32.const 1
+    i32.le_u)
+
+  (func (export "test_i32_le_u_2") (result i32)
+    call $i32_le_u_2)
+
+  (func $i32_le_u_2 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.le_u)
+
+  (func (export "test_i32_le_u_3") (result i32)
+    call $i32_le_u_3)
+
+  (func $i32_le_u_3 (result i32)
+    i32.const 1
+    i32.const 0xffffffff
+    i32.le_u)
+
+  (func (export "test_i32_ge_s_1") (result i32)
+    call $i32_ge_s_1)
+
+  (func $i32_ge_s_1 (result i32)
+    i32.const -1
+    i32.const 1
+    i32.ge_s)
+
+  (func (export "test_i32_ge_s_2") (result i32)
+    call $i32_ge_s_2)
+
+  (func $i32_ge_s_2 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.ge_s)
+
+  (func (export "test_i32_ge_s_3") (result i32)
+    call $i32_ge_s_3)
+
+  (func $i32_ge_s_3 (result i32)
+    i32.const 1
+    i32.const -1
+    i32.ge_s)
+
+  (func (export "test_i32_ge_u_1") (result i32)
+    call $i32_ge_u_1)
+
+  (func $i32_ge_u_1 (result i32)
+    i32.const 0xffffffff
+    i32.const 1
+    i32.ge_u)
+
+  (func (export "test_i32_ge_u_2") (result i32)
+    call $i32_ge_u_2)
+
+  (func $i32_ge_u_2 (result i32)
+    i32.const 0
+    i32.const 0
+    i32.ge_u)
+
+  (func (export "test_i32_ge_u_3") (result i32)
+    call $i32_ge_u_3)
+
+  (func $i32_ge_u_3 (result i32)
+    i32.const 1
+    i32.const 0xffffffff
+    i32.ge_u)
+)
+(;; STDOUT ;;;
+test_i32_eqz_1() => i32:1
+test_i32_eqz_2() => i32:0
+test_i32_eqz_3() => i32:0
+test_i32_eq_1() => i32:1
+test_i32_eq_2() => i32:0
+test_i32_eq_3() => i32:1
+test_i32_eq_4() => i32:0
+test_i32_ne_1() => i32:0
+test_i32_ne_2() => i32:1
+test_i32_ne_3() => i32:0
+test_i32_ne_4() => i32:1
+test_i32_lt_s_1() => i32:1
+test_i32_lt_s_2() => i32:0
+test_i32_lt_s_3() => i32:0
+test_i32_lt_u_1() => i32:0
+test_i32_lt_u_2() => i32:0
+test_i32_lt_u_3() => i32:1
+test_i32_gt_s_1() => i32:0
+test_i32_gt_s_2() => i32:0
+test_i32_gt_s_3() => i32:1
+test_i32_gt_u_1() => i32:1
+test_i32_gt_u_2() => i32:0
+test_i32_gt_u_3() => i32:0
+test_i32_le_s_1() => i32:1
+test_i32_le_s_2() => i32:1
+test_i32_le_s_3() => i32:0
+test_i32_le_u_1() => i32:0
+test_i32_le_u_2() => i32:1
+test_i32_le_u_3() => i32:1
+test_i32_ge_s_1() => i32:0
+test_i32_ge_s_2() => i32:1
+test_i32_ge_s_3() => i32:1
+test_i32_ge_u_1() => i32:1
+test_i32_ge_u_2() => i32:1
+test_i32_ge_u_3() => i32:0
+;;; STDOUT ;;)


### PR DESCRIPTION
This PR implements the following opcodes for i32 comparison:

- `i32.eqz`
- `i32.eq`
- `i32.ne`
- `i32.lt_s`
- `i32.lt_u`
- `i32.gt_s`
- `i32.gt_u`
- `i32.le_s`
- `i32.le_u`
- `i32.ge_s`
- `i32.ge_u`