### PR TITLE
Add missing i32 arithmetic opcode tests

### DIFF
--- a/test/jit/i32_arithmetic.txt
+++ b/test/jit/i32_arithmetic.txt
@@ -1,0 +1,216 @@
+;;; TOOL: run-interp-jit
+(module
+  ;; Tests from third_party/testsuite/i32.wast, converted for jit compilation
+  ;; When params work, this can be simplified!
+
+
+  ;; Add
+  (func (export "test_add_1_i32") (result i32) call $add_1_i32)
+  (func (export "test_add_2_i32") (result i32) call $add_2_i32)
+  (func (export "test_add_3_i32") (result i32) call $add_3_i32)
+  (func (export "test_add_4_i32") (result i32) call $add_4_i32)
+  (func (export "test_add_5_i32") (result i32) call $add_5_i32)
+  (func (export "test_add_6_i32") (result i32) call $add_6_i32)
+  (func (export "test_add_7_i32") (result i32) call $add_7_i32)
+  (func (export "test_add_8_i32") (result i32) call $add_8_i32)
+
+  (func $add_1_i32 (result i32) i32.const 1 i32.const 1 i32.add return)
+  (func $add_2_i32 (result i32) i32.const 1 i32.const 0 i32.add return)
+  (func $add_3_i32 (result i32) i32.const -1 i32.const -1 i32.add return)
+  (func $add_4_i32 (result i32) i32.const -1 i32.const 1 i32.add return)
+  (func $add_5_i32 (result i32) i32.const 0x7fffffff i32.const 1 i32.add return)
+  (func $add_6_i32 (result i32) i32.const 0x80000000 i32.const -1 i32.add return)
+  (func $add_7_i32 (result i32) i32.const 0x80000000 i32.const 0x80000000 i32.add return)
+  (func $add_8_i32 (result i32) i32.const 0x3fffffff i32.const 1 i32.add return)
+
+  ;; Sub
+  (func (export "test_sub_1_i32") (result i32) call $sub_1_i32)
+  (func (export "test_sub_2_i32") (result i32) call $sub_2_i32)
+  (func (export "test_sub_3_i32") (result i32) call $sub_3_i32)
+  (func (export "test_sub_4_i32") (result i32) call $sub_4_i32)
+  (func (export "test_sub_5_i32") (result i32) call $sub_5_i32)
+  (func (export "test_sub_6_i32") (result i32) call $sub_6_i32)
+  (func (export "test_sub_7_i32") (result i32) call $sub_7_i32)
+  (func (export "test_sub_8_i32") (result i32) call $sub_8_i32)
+
+  (func $sub_1_i32 (result i32) i32.const 1 i32.const 1 i32.sub return)
+  (func $sub_2_i32 (result i32) i32.const 1 i32.const 0 i32.sub return)
+  (func $sub_3_i32 (result i32) i32.const -1 i32.const -1 i32.sub return)
+  (func $sub_4_i32 (result i32) i32.const -1 i32.const 1 i32.sub return)
+  (func $sub_5_i32 (result i32) i32.const 0x7fffffff i32.const -1 i32.sub return)
+  (func $sub_6_i32 (result i32) i32.const 0x80000000 i32.const 1 i32.sub return)
+  (func $sub_7_i32 (result i32) i32.const 0x80000000 i32.const 0x80000000 i32.sub return)
+  (func $sub_8_i32 (result i32) i32.const 0x3fffffff i32.const -1 i32.sub return)
+
+  ;; Mul
+  (func (export "test_mul_1_i32") (result i32) call $mul_1_i32)
+  (func (export "test_mul_2_i32") (result i32) call $mul_2_i32)
+  (func (export "test_mul_3_i32") (result i32) call $mul_3_i32)
+  (func (export "test_mul_4_i32") (result i32) call $mul_4_i32)
+  (func (export "test_mul_5_i32") (result i32) call $mul_5_i32)
+  (func (export "test_mul_6_i32") (result i32) call $mul_6_i32)
+  (func (export "test_mul_7_i32") (result i32) call $mul_7_i32)
+  (func (export "test_mul_8_i32") (result i32) call $mul_8_i32)
+  (func (export "test_mul_9_i32") (result i32) call $mul_9_i32)
+
+  (func $mul_1_i32 (result i32) i32.const 1 i32.const 1 i32.mul return)
+  (func $mul_2_i32 (result i32) i32.const 1 i32.const 0 i32.mul return)
+  (func $mul_3_i32 (result i32) i32.const -1 i32.const -1 i32.mul return)
+  (func $mul_4_i32 (result i32) i32.const 0x10000000 i32.const 4096 i32.mul return)
+  (func $mul_5_i32 (result i32) i32.const 0x80000000 i32.const 0 i32.mul return)
+  (func $mul_6_i32 (result i32) i32.const 0x80000000 i32.const -1 i32.mul return)
+  (func $mul_7_i32 (result i32) i32.const 0x7fffffff i32.const -1 i32.mul return)
+  (func $mul_8_i32 (result i32) i32.const 0x01234567 i32.const 0x76543210 i32.mul return)
+  (func $mul_9_i32 (result i32) i32.const 0x7fffffff i32.const 0x7fffffff i32.mul return)
+
+  ;; Div_s
+  (func (export "test_div_s_1_i32") (result i32) call $div_s_1_i32)
+  (func (export "test_div_s_2_i32") (result i32) call $div_s_2_i32)
+  (func (export "test_div_s_3_i32") (result i32) call $div_s_3_i32)
+  (func (export "test_div_s_4_i32") (result i32) call $div_s_4_i32)
+  (func (export "test_div_s_5_i32") (result i32) call $div_s_5_i32)
+  (func (export "test_div_s_6_i32") (result i32) call $div_s_6_i32)
+  (func (export "test_div_s_7_i32") (result i32) call $div_s_7_i32)
+  (func (export "test_div_s_8_i32") (result i32) call $div_s_8_i32)
+  (func (export "test_div_s_9_i32") (result i32) call $div_s_9_i32)
+  (func (export "test_div_s_10_i32") (result i32) call $div_s_10_i32)
+  (func (export "test_div_s_11_i32") (result i32) call $div_s_11_i32)
+  (func (export "test_div_s_12_i32") (result i32) call $div_s_12_i32)
+  (func (export "test_div_s_13_i32") (result i32) call $div_s_13_i32)
+  (func (export "test_div_s_14_i32") (result i32) call $div_s_14_i32)
+  (func (export "test_div_s_15_i32") (result i32) call $div_s_15_i32)
+  (func (export "test_div_s_16_i32") (result i32) call $div_s_16_i32)
+  (func (export "test_div_s_17_i32") (result i32) call $div_s_17_i32)
+  (func (export "test_div_s_18_i32") (result i32) call $div_s_18_i32)
+  (func (export "test_div_s_19_i32") (result i32) call $div_s_19_i32)
+
+  (func $div_s_1_i32 (result i32) i32.const 1 i32.const 0 i32.div_s return)
+  (func $div_s_2_i32 (result i32) i32.const 0 i32.const 0 i32.div_s return)
+  (func $div_s_3_i32 (result i32) i32.const 0x80000000 i32.const -1 i32.div_s return)
+  (func $div_s_4_i32 (result i32) i32.const 1 i32.const 1 i32.div_s return)
+  (func $div_s_5_i32 (result i32) i32.const 0 i32.const 1 i32.div_s return)
+  (func $div_s_6_i32 (result i32) i32.const 0 i32.const -1 i32.div_s return)
+  (func $div_s_7_i32 (result i32) i32.const -1 i32.const -1 i32.div_s return)
+  (func $div_s_8_i32 (result i32) i32.const 0x80000000 i32.const 2 i32.div_s return)
+  (func $div_s_9_i32 (result i32) i32.const 0x80000001 i32.const 1000 i32.div_s return)
+  (func $div_s_10_i32 (result i32) i32.const 5 i32.const 2 i32.div_s return)
+  (func $div_s_11_i32 (result i32) i32.const -5 i32.const 2 i32.div_s return)
+  (func $div_s_12_i32 (result i32) i32.const 5 i32.const -2 i32.div_s return)
+  (func $div_s_13_i32 (result i32) i32.const -5 i32.const -2 i32.div_s return)
+  (func $div_s_14_i32 (result i32) i32.const 7 i32.const 3 i32.div_s return)
+  (func $div_s_15_i32 (result i32) i32.const -7 i32.const 3 i32.div_s return)
+  (func $div_s_16_i32 (result i32) i32.const 7 i32.const -3 i32.div_s return)
+  (func $div_s_17_i32 (result i32) i32.const -7 i32.const -3 i32.div_s return)
+  (func $div_s_18_i32 (result i32) i32.const 11 i32.const 5 i32.div_s return)
+  (func $div_s_19_i32 (result i32) i32.const 17 i32.const 7 i32.div_s return)
+
+  ;; Rem_s
+  (func (export "test_rem_s_1_i32") (result i32) call $rem_s_1_i32)
+  (func (export "test_rem_s_2_i32") (result i32) call $rem_s_2_i32)
+  (func (export "test_rem_s_3_i32") (result i32) call $rem_s_3_i32)
+  (func (export "test_rem_s_4_i32") (result i32) call $rem_s_4_i32)
+  (func (export "test_rem_s_5_i32") (result i32) call $rem_s_5_i32)
+  (func (export "test_rem_s_6_i32") (result i32) call $rem_s_6_i32)
+  (func (export "test_rem_s_7_i32") (result i32) call $rem_s_7_i32)
+  (func (export "test_rem_s_8_i32") (result i32) call $rem_s_8_i32)
+  (func (export "test_rem_s_9_i32") (result i32) call $rem_s_9_i32)
+  (func (export "test_rem_s_10_i32") (result i32) call $rem_s_10_i32)
+  (func (export "test_rem_s_11_i32") (result i32) call $rem_s_11_i32)
+  (func (export "test_rem_s_12_i32") (result i32) call $rem_s_12_i32)
+  (func (export "test_rem_s_13_i32") (result i32) call $rem_s_13_i32)
+  (func (export "test_rem_s_14_i32") (result i32) call $rem_s_14_i32)
+  (func (export "test_rem_s_15_i32") (result i32) call $rem_s_15_i32)
+  (func (export "test_rem_s_16_i32") (result i32) call $rem_s_16_i32)
+  (func (export "test_rem_s_17_i32") (result i32) call $rem_s_17_i32)
+  (func (export "test_rem_s_18_i32") (result i32) call $rem_s_18_i32)
+  (func (export "test_rem_s_19_i32") (result i32) call $rem_s_19_i32)
+  (func (export "test_rem_s_20_i32") (result i32) call $rem_s_20_i32)
+
+  (func $rem_s_1_i32 (result i32) i32.const 1 i32.const 0 i32.rem_s return)
+  (func $rem_s_2_i32 (result i32) i32.const 0 i32.const 0 i32.rem_s return)
+  (func $rem_s_3_i32 (result i32) i32.const 0x7fffffff i32.const -1 i32.rem_s return)
+  (func $rem_s_4_i32 (result i32) i32.const 1 i32.const 1 i32.rem_s return)
+  (func $rem_s_5_i32 (result i32) i32.const 0 i32.const 1 i32.rem_s return)
+  (func $rem_s_6_i32 (result i32) i32.const 0 i32.const -1 i32.rem_s return)
+  (func $rem_s_7_i32 (result i32) i32.const -1 i32.const -1 i32.rem_s return)
+  (func $rem_s_8_i32 (result i32) i32.const 0x80000000 i32.const -1 i32.rem_s return)
+  (func $rem_s_9_i32 (result i32) i32.const 0x80000000 i32.const 2 i32.rem_s return)
+  (func $rem_s_10_i32 (result i32) i32.const 0x80000001 i32.const 1000 i32.rem_s return)
+  (func $rem_s_11_i32 (result i32) i32.const 5 i32.const 2 i32.rem_s return)
+  (func $rem_s_12_i32 (result i32) i32.const -5 i32.const 2 i32.rem_s return)
+  (func $rem_s_13_i32 (result i32) i32.const 5 i32.const -2 i32.rem_s return)
+  (func $rem_s_14_i32 (result i32) i32.const -5 i32.const -2 i32.rem_s return)
+  (func $rem_s_15_i32 (result i32) i32.const 7 i32.const 3 i32.rem_s return)
+  (func $rem_s_16_i32 (result i32) i32.const -7 i32.const 3 i32.rem_s return)
+  (func $rem_s_17_i32 (result i32) i32.const 7 i32.const -3 i32.rem_s return)
+  (func $rem_s_18_i32 (result i32) i32.const -7 i32.const -3 i32.rem_s return)
+  (func $rem_s_19_i32 (result i32) i32.const 11 i32.const 5 i32.rem_s return)
+  (func $rem_s_20_i32 (result i32) i32.const 17 i32.const 7 i32.rem_s return)
+  
+)
+(;; STDOUT ;;;
+test_add_1_i32() => i32:2
+test_add_2_i32() => i32:1
+test_add_3_i32() => i32:4294967294
+test_add_4_i32() => i32:0
+test_add_5_i32() => i32:2147483648
+test_add_6_i32() => i32:2147483647
+test_add_7_i32() => i32:0
+test_add_8_i32() => i32:1073741824
+test_sub_1_i32() => i32:0
+test_sub_2_i32() => i32:1
+test_sub_3_i32() => i32:0
+test_sub_4_i32() => i32:4294967294
+test_sub_5_i32() => i32:2147483648
+test_sub_6_i32() => i32:2147483647
+test_sub_7_i32() => i32:0
+test_sub_8_i32() => i32:1073741824
+test_mul_1_i32() => i32:1
+test_mul_2_i32() => i32:0
+test_mul_3_i32() => i32:1
+test_mul_4_i32() => i32:0
+test_mul_5_i32() => i32:0
+test_mul_6_i32() => i32:2147483648
+test_mul_7_i32() => i32:2147483649
+test_mul_8_i32() => i32:898528368
+test_mul_9_i32() => i32:1
+test_div_s_1_i32() => error: integer divide by zero
+test_div_s_2_i32() => error: integer divide by zero
+test_div_s_3_i32() => error: integer overflow
+test_div_s_4_i32() => i32:1
+test_div_s_5_i32() => i32:0
+test_div_s_6_i32() => i32:0
+test_div_s_7_i32() => i32:1
+test_div_s_8_i32() => i32:3221225472
+test_div_s_9_i32() => i32:4292819813
+test_div_s_10_i32() => i32:2
+test_div_s_11_i32() => i32:4294967294
+test_div_s_12_i32() => i32:4294967294
+test_div_s_13_i32() => i32:2
+test_div_s_14_i32() => i32:2
+test_div_s_15_i32() => i32:4294967294
+test_div_s_16_i32() => i32:4294967294
+test_div_s_17_i32() => i32:2
+test_div_s_18_i32() => i32:2
+test_div_s_19_i32() => i32:2
+test_rem_s_1_i32() => error: integer divide by zero
+test_rem_s_2_i32() => error: integer divide by zero
+test_rem_s_3_i32() => i32:0
+test_rem_s_4_i32() => i32:0
+test_rem_s_5_i32() => i32:0
+test_rem_s_6_i32() => i32:0
+test_rem_s_7_i32() => i32:0
+test_rem_s_8_i32() => i32:0
+test_rem_s_9_i32() => i32:0
+test_rem_s_10_i32() => i32:4294966649
+test_rem_s_11_i32() => i32:1
+test_rem_s_12_i32() => i32:4294967295
+test_rem_s_13_i32() => i32:1
+test_rem_s_14_i32() => i32:4294967295
+test_rem_s_15_i32() => i32:1
+test_rem_s_16_i32() => i32:4294967295
+test_rem_s_17_i32() => i32:1
+test_rem_s_18_i32() => i32:4294967295
+test_rem_s_19_i32() => i32:1
+test_rem_s_20_i32() => i32:3
+;;; STDOUT ;;)


### PR DESCRIPTION
Added the arithmetic opcode tests for i32, since they were missed when the opcodes were implemented.

Closes #68. 