### PR TITLE
Add i64 comparison opcodes and tests.

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -802,6 +802,72 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       });
       break;
 
+    case Opcode::I64Eqz:
+      EmitUnaryOp<int64_t, int>(b, [&](TR::IlValue* val) {
+        return b->EqualTo(val, b->ConstInt64(0));
+      });
+      break;
+
+    case Opcode::I64Eq:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->EqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I64Ne:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->NotEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I64LtS:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->LessThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I64LtU:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->UnsignedLessThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I64GtS:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->GreaterThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I64GtU:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->UnsignedGreaterThan(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I64LeS:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->LessOrEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I64LeU:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->UnsignedLessOrEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I64GeS:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->GreaterOrEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::I64GeU:
+      EmitBinaryOp<int64_t, int>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        return b->UnsignedGreaterOrEqualTo(lhs, rhs);
+      });
+      break;
+
     case Opcode::F32Abs:
       EmitUnaryOp<float>(b, [&](TR::IlValue* value) {
         auto* return_value = b->Copy(value);

--- a/test/jit/i64_comparison.txt
+++ b/test/jit/i64_comparison.txt
@@ -1,0 +1,316 @@
+;;; TOOL: run-interp-jit
+(module
+  (func (export "test_i64_eqz_1") (result i32)
+    call $i64_eqz_1)
+
+  (func $i64_eqz_1 (result i32)
+    i64.const 0
+    i64.eqz)
+
+  (func (export "test_i64_eqz_2") (result i32)
+    call $i64_eqz_2)
+
+  (func $i64_eqz_2 (result i32)
+    i64.const -1
+    i64.eqz)
+
+  (func (export "test_i64_eqz_3") (result i32)
+    call $i64_eqz_3)
+
+  (func $i64_eqz_3 (result i32)
+    i64.const 1
+    i64.eqz)
+
+  (func (export "test_i64_eq_1") (result i32)
+    call $i64_eq_1)
+
+  (func $i64_eq_1 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.eq)
+
+  (func (export "test_i64_eq_2") (result i32)
+    call $i64_eq_2)
+
+  (func $i64_eq_2 (result i32)
+    i64.const 0xffffffffffffffff
+    i64.const 0
+    i64.eq)
+
+  (func (export "test_i64_eq_3") (result i32)
+    call $i64_eq_3)
+
+  (func $i64_eq_3 (result i32)
+    i64.const 0xffffffffffffffff
+    i64.const 0xffffffffffffffff
+    i64.eq)
+
+  (func (export "test_i64_eq_4") (result i32)
+    call $i64_eq_4)
+
+  (func $i64_eq_4 (result i32)
+    i64.const 33
+    i64.const 32
+    i64.eq)
+
+  (func (export "test_i64_ne_1") (result i32)
+    call $i64_ne_1)
+
+  (func $i64_ne_1 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.ne)
+
+  (func (export "test_i64_ne_2") (result i32)
+    call $i64_ne_2)
+
+  (func $i64_ne_2 (result i32)
+    i64.const 0xffffffffffffffff
+    i64.const 0
+    i64.ne)
+
+  (func (export "test_i64_ne_3") (result i32)
+    call $i64_ne_3)
+
+  (func $i64_ne_3 (result i32)
+    i64.const 0xffffffffffffffff
+    i64.const 0xffffffffffffffff
+    i64.ne)
+
+  (func (export "test_i64_ne_4") (result i32)
+    call $i64_ne_4)
+
+  (func $i64_ne_4 (result i32)
+    i64.const 33
+    i64.const 32
+    i64.ne)
+
+  (func (export "test_i64_lt_s_1") (result i32)
+    call $i64_lt_s_1)
+
+  (func $i64_lt_s_1 (result i32)
+    i64.const -1
+    i64.const 1
+    i64.lt_s)
+
+  (func (export "test_i64_lt_s_2") (result i32)
+    call $i64_lt_s_2)
+
+  (func $i64_lt_s_2 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.lt_s)
+
+  (func (export "test_i64_lt_s_3") (result i32)
+    call $i64_lt_s_3)
+
+  (func $i64_lt_s_3 (result i32)
+    i64.const 1
+    i64.const -1
+    i64.lt_s)
+
+  (func (export "test_i64_lt_u_1") (result i32)
+    call $i64_lt_u_1)
+
+  (func $i64_lt_u_1 (result i32)
+    i64.const 0xffffffffffffffff
+    i64.const 1
+    i64.lt_u)
+
+  (func (export "test_i64_lt_u_2") (result i32)
+    call $i64_lt_u_2)
+
+  (func $i64_lt_u_2 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.lt_u)
+
+  (func (export "test_i64_lt_u_3") (result i32)
+    call $i64_lt_u_3)
+
+  (func $i64_lt_u_3 (result i32)
+    i64.const 1
+    i64.const 0xffffffffffffffff
+    i64.lt_u)
+
+  (func (export "test_i64_gt_s_1") (result i32)
+    call $i64_gt_s_1)
+
+  (func $i64_gt_s_1 (result i32)
+    i64.const -1
+    i64.const 1
+    i64.gt_s)
+
+  (func (export "test_i64_gt_s_2") (result i32)
+    call $i64_gt_s_2)
+
+  (func $i64_gt_s_2 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.gt_s)
+
+  (func (export "test_i64_gt_s_3") (result i32)
+    call $i64_gt_s_3)
+
+  (func $i64_gt_s_3 (result i32)
+    i64.const 1
+    i64.const -1
+    i64.gt_s)
+
+  (func (export "test_i64_gt_u_1") (result i32)
+    call $i64_gt_u_1)
+
+  (func $i64_gt_u_1 (result i32)
+    i64.const 0xffffffffffffffff
+    i64.const 1
+    i64.gt_u)
+
+  (func (export "test_i64_gt_u_2") (result i32)
+    call $i64_gt_u_2)
+
+  (func $i64_gt_u_2 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.gt_u)
+
+  (func (export "test_i64_gt_u_3") (result i32)
+    call $i64_gt_u_3)
+
+  (func $i64_gt_u_3 (result i32)
+    i64.const 1
+    i64.const 0xffffffffffffffff
+    i64.gt_u)
+
+  (func (export "test_i64_le_s_1") (result i32)
+    call $i64_le_s_1)
+
+  (func $i64_le_s_1 (result i32)
+    i64.const -1
+    i64.const 1
+    i64.le_s)
+
+  (func (export "test_i64_le_s_2") (result i32)
+    call $i64_le_s_2)
+
+  (func $i64_le_s_2 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.le_s)
+
+  (func (export "test_i64_le_s_3") (result i32)
+    call $i64_le_s_3)
+
+  (func $i64_le_s_3 (result i32)
+    i64.const 1
+    i64.const -1
+    i64.le_s)
+
+  (func (export "test_i64_le_u_1") (result i32)
+    call $i64_le_u_1)
+
+  (func $i64_le_u_1 (result i32)
+    i64.const 0xffffffffffffffff
+    i64.const 1
+    i64.le_u)
+
+  (func (export "test_i64_le_u_2") (result i32)
+    call $i64_le_u_2)
+
+  (func $i64_le_u_2 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.le_u)
+
+  (func (export "test_i64_le_u_3") (result i32)
+    call $i64_le_u_3)
+
+  (func $i64_le_u_3 (result i32)
+    i64.const 1
+    i64.const 0xffffffffffffffff
+    i64.le_u)
+
+  (func (export "test_i64_ge_s_1") (result i32)
+    call $i64_ge_s_1)
+
+  (func $i64_ge_s_1 (result i32)
+    i64.const -1
+    i64.const 1
+    i64.ge_s)
+
+  (func (export "test_i64_ge_s_2") (result i32)
+    call $i64_ge_s_2)
+
+  (func $i64_ge_s_2 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.ge_s)
+
+  (func (export "test_i64_ge_s_3") (result i32)
+    call $i64_ge_s_3)
+
+  (func $i64_ge_s_3 (result i32)
+    i64.const 1
+    i64.const -1
+    i64.ge_s)
+
+  (func (export "test_i64_ge_u_1") (result i32)
+    call $i64_ge_u_1)
+
+  (func $i64_ge_u_1 (result i32)
+    i64.const 0xffffffffffffffff
+    i64.const 1
+    i64.ge_u)
+
+  (func (export "test_i64_ge_u_2") (result i32)
+    call $i64_ge_u_2)
+
+  (func $i64_ge_u_2 (result i32)
+    i64.const 0
+    i64.const 0
+    i64.ge_u)
+
+  (func (export "test_i64_ge_u_3") (result i32)
+    call $i64_ge_u_3)
+
+  (func $i64_ge_u_3 (result i32)
+    i64.const 1
+    i64.const 0xffffffffffffffff
+    i64.ge_u)
+)
+(;; STDOUT ;;;
+test_i64_eqz_1() => i32:1
+test_i64_eqz_2() => i32:0
+test_i64_eqz_3() => i32:0
+test_i64_eq_1() => i32:1
+test_i64_eq_2() => i32:0
+test_i64_eq_3() => i32:1
+test_i64_eq_4() => i32:0
+test_i64_ne_1() => i32:0
+test_i64_ne_2() => i32:1
+test_i64_ne_3() => i32:0
+test_i64_ne_4() => i32:1
+test_i64_lt_s_1() => i32:1
+test_i64_lt_s_2() => i32:0
+test_i64_lt_s_3() => i32:0
+test_i64_lt_u_1() => i32:0
+test_i64_lt_u_2() => i32:0
+test_i64_lt_u_3() => i32:1
+test_i64_gt_s_1() => i32:0
+test_i64_gt_s_2() => i32:0
+test_i64_gt_s_3() => i32:1
+test_i64_gt_u_1() => i32:1
+test_i64_gt_u_2() => i32:0
+test_i64_gt_u_3() => i32:0
+test_i64_le_s_1() => i32:1
+test_i64_le_s_2() => i32:1
+test_i64_le_s_3() => i32:0
+test_i64_le_u_1() => i32:0
+test_i64_le_u_2() => i32:1
+test_i64_le_u_3() => i32:1
+test_i64_ge_s_1() => i32:0
+test_i64_ge_s_2() => i32:1
+test_i64_ge_s_3() => i32:1
+test_i64_ge_u_1() => i32:1
+test_i64_ge_u_2() => i32:1
+test_i64_ge_u_3() => i32:0
+;;; STDOUT ;;)


### PR DESCRIPTION
Adds support for:

- `i64.eqz`
- `i64.eq`
- `i64.ne`
- `i64.lt_s`
- `i64.lt_u`
- `i64.gt_s`
- `i64.gt_u`
- `i64.le_s`
- `i64.le_u`
- `i64.ge_s`
- `i64.ge_u`

Along with relevant tests.
Closes #73 