### PR TITLE
Implement CallHost and CallIndirect opcodes

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -25,6 +25,7 @@
 #include <limits>
 
 namespace wabt {
+
 namespace jit {
 
 using ResultEnum = std::underlying_type<wabt::interp::Result>::type;
@@ -84,6 +85,13 @@ inline Opcode ReadOpcodeAt(const uint8_t* pc) {
       return static_cast<Result_t>(result);      \
     }                                            \
   } while (0)
+#define TRAP(type) return static_cast<Result_t>(wabt::interp::Result::Trap##type)
+#define TRAP_UNLESS(cond, type) TRAP_IF(!(cond), type)
+#define TRAP_IF(cond, type)  \
+  do {                       \
+    if (WABT_UNLIKELY(cond)) \
+      TRAP(type);            \
+  } while (0)
 
 FunctionBuilder::Result_t FunctionBuilder::CallHelper(wabt::interp::Thread* th, wabt::interp::IstreamOffset offset, uint8_t* current_pc) {
   // no need to check if JIT was enabled since we can only get here it was
@@ -133,6 +141,27 @@ FunctionBuilder::Result_t FunctionBuilder::CallHelper(wabt::interp::Thread* th, 
   return static_cast<Result_t>(wabt::interp::Result::Ok);
 }
 
+
+FunctionBuilder::Result_t FunctionBuilder::CallIndirectHelper(wabt::interp::Thread* th, Index table_index, Index sig_index, Index entry_index, uint8_t* current_pc) {
+  using namespace wabt::interp;
+  auto* env = th->env_;
+  Table* table = &env->tables_[table_index];
+  TRAP_IF(entry_index >= table->func_indexes.size(), UndefinedTableIndex);
+  Index func_index = table->func_indexes[entry_index];
+  TRAP_IF(func_index == kInvalidIndex, UninitializedTableElement);
+  Func* func = env->funcs_[func_index].get();
+  TRAP_UNLESS(env->FuncSignaturesAreEqual(func->sig_index, sig_index),
+              IndirectCallSignatureMismatch);
+  if (func->is_host) {
+    th->CallHost(cast<HostFunc>(func));
+  } else {
+    auto result = CallHelper(th, cast<DefinedFunc>(func)->offset, current_pc);
+    if (result != static_cast<Result_t>(interp::Result::Ok))
+      return result;
+  }
+  return static_cast<Result_t>(interp::Result::Ok);
+}
+
 void FunctionBuilder::CallHostHelper(wabt::interp::Thread* th, Index func_index) {
   th->CallHost(cast<wabt::interp::HostFunc>(th->env_->funcs_[func_index].get()));
 }
@@ -166,6 +195,15 @@ FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn
                  3,
                  types->toIlType<void*>(),
                  types->toIlType<wabt::interp::IstreamOffset>(),
+                 types->PointerTo(Int8));
+  DefineFunction("CallIndirectHelper", __FILE__, "0",
+                 reinterpret_cast<void*>(CallIndirectHelper),
+                 types->toIlType<Result_t>(),
+                 5,
+                 types->toIlType<void*>(),
+                 types->toIlType<Index>(),
+                 types->toIlType<Index>(),
+                 types->toIlType<Index>(),
                  types->PointerTo(Int8));
   DefineFunction("CallHostHelper", __FILE__, "0",
                  reinterpret_cast<void*>(CallHostHelper),
@@ -569,6 +607,29 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 
       b->Store("result",
       b->      Call("CallHelper", 3, th_addr, offset, current_pc));
+
+      TR::IlBuilder* trap_handler = nullptr;
+
+      b->IfThen(&trap_handler,
+      b->       NotEqualTo(
+      b->                  Load("result"),
+      b->                  Const(static_cast<Result_t>(wabt::interp::Result::Ok))));
+
+      trap_handler->Return(
+      trap_handler->       Load("result"));
+
+      break;
+    }
+
+    case Opcode::CallIndirect: {
+      auto th_addr = b->ConstAddress(thread_);
+      auto table_index = b->ConstInt32(ReadU32(&pc));
+      auto sig_index = b->ConstInt32(ReadU32(&pc));
+      auto entry_index = Pop(b, "i32");
+      auto current_pc = b->Const(pc);
+
+      b->Store("result",
+      b->      Call("CallIndirectHelper", 5, th_addr, table_index, sig_index, entry_index, current_pc));
 
       TR::IlBuilder* trap_handler = nullptr;
 

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -107,6 +107,8 @@ class FunctionBuilder : public TR::MethodBuilder {
 
   static Result_t CallHelper(wabt::interp::Thread* th, wabt::interp::IstreamOffset offset, uint8_t* current_pc);
 
+  static Result_t CallIndirectHelper(wabt::interp::Thread* th, Index table_index, Index sig_index, Index entry_index, uint8_t* current_pc);
+
   static void CallHostHelper(wabt::interp::Thread* th, Index func_index);
 
   std::vector<BytecodeWorkItem> workItems_;

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -107,6 +107,8 @@ class FunctionBuilder : public TR::MethodBuilder {
 
   static Result_t CallHelper(wabt::interp::Thread* th, wabt::interp::IstreamOffset offset, uint8_t* current_pc);
 
+  static void CallHostHelper(wabt::interp::Thread* th, Index func_index);
+
   std::vector<BytecodeWorkItem> workItems_;
 
   interp::Thread* thread_;

--- a/test/jit/callindirect.txt
+++ b/test/jit/callindirect.txt
@@ -1,0 +1,69 @@
+;;; TOOL: run-interp
+(module
+  (type $v_i (func (result i32)))
+  (func $zero (type $v_i) 
+     i32.const 0)
+  (func $one (type $v_i) 
+     i32.const 1)
+
+  (func $nullary (param i32) (result i32)
+    get_local 0
+    call_indirect $v_i)
+
+  (type $ii_i (func (param i32 i32) (result i32)))
+  (func $add (type $ii_i)
+    get_local 0 
+    get_local 1
+    i32.add)
+  (func $sub (type $ii_i)
+     get_local 0
+     get_local 1 
+     i32.sub)
+
+  (func $binary (param i32 i32 i32) (result i32)
+    get_local 0
+    get_local 1
+    get_local 2
+    call_indirect $ii_i)
+
+  (table anyfunc (elem $zero $one $add $sub))
+
+  (func (export "test_zero") (result i32)
+    i32.const 0
+    call $nullary)
+
+  (func (export "test_one") (result i32)
+    i32.const 1
+    call $nullary)
+
+  (func (export "test_add") (result i32)
+    i32.const 10
+    i32.const 4
+    i32.const 2
+    call $binary)
+
+  (func (export "test_sub") (result i32)
+    i32.const 10
+    i32.const 4
+    i32.const 3
+    call $binary)
+
+  (func (export "trap_oob") (result i32)
+    i32.const 10
+    i32.const 4
+    i32.const 4
+    call $binary)
+
+  (func (export "trap_sig_mismatch") (result i32)
+    i32.const 10
+    i32.const 4
+    i32.const 0
+    call $binary))
+(;; STDOUT ;;;
+test_zero() => i32:0
+test_one() => i32:1
+test_add() => i32:14
+test_sub() => i32:6
+trap_oob() => error: undefined table index
+trap_sig_mismatch() => error: indirect call signature mismatch
+;;; STDOUT ;;)


### PR DESCRIPTION
This changeset implements the following opcodes:

- `InterpCallHost`
- `CallIndirect`

Closes #53 
Closes #75