### PR TITLE
Implement basic memory loads and stores

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -717,6 +717,30 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       b->  LoadAt(typeDictionary()->PointerTo(Double), EmitMemoryPreAccess<double>(b, &pc)));
       break;
 
+    case Opcode::I32Store: {
+      auto value = Pop(b, "i32");
+      b->StoreAt(EmitMemoryPreAccess<int32_t>(b, &pc), value);
+      break;
+    }
+
+    case Opcode::I64Store: {
+      auto value = Pop(b, "i64");
+      b->StoreAt(EmitMemoryPreAccess<int64_t>(b, &pc), value);
+      break;
+    }
+
+    case Opcode::F32Store: {
+      auto value = Pop(b, "f32");
+      b->StoreAt(EmitMemoryPreAccess<float>(b, &pc), value);
+      break;
+    }
+
+    case Opcode::F64Store: {
+      auto value = Pop(b, "f64");
+      b->StoreAt(EmitMemoryPreAccess<double>(b, &pc), value);
+      break;
+    }
+
     case Opcode::I32Add:
       EmitBinaryOp<int32_t>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Add(lhs, rhs);

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -141,7 +141,6 @@ FunctionBuilder::Result_t FunctionBuilder::CallHelper(wabt::interp::Thread* th, 
   return static_cast<Result_t>(wabt::interp::Result::Ok);
 }
 
-
 FunctionBuilder::Result_t FunctionBuilder::CallIndirectHelper(wabt::interp::Thread* th, Index table_index, Index sig_index, Index entry_index, uint8_t* current_pc) {
   using namespace wabt::interp;
   auto* env = th->env_;
@@ -164,6 +163,16 @@ FunctionBuilder::Result_t FunctionBuilder::CallIndirectHelper(wabt::interp::Thre
 
 void FunctionBuilder::CallHostHelper(wabt::interp::Thread* th, Index func_index) {
   th->CallHost(cast<wabt::interp::HostFunc>(th->env_->funcs_[func_index].get()));
+}
+
+void* FunctionBuilder::MemoryTranslationHelper(interp::Thread* th, uint32_t memory_id, uint64_t address, uint32_t size) {
+  auto* memory = &th->env_->memories_[memory_id];
+
+  if (address + size > memory->data.size()) {
+    return nullptr;
+  } else {
+    return memory->data.data() + address;
+  }
 }
 
 FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn, TypeDictionary* types)
@@ -211,6 +220,14 @@ FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn
                  2,
                  types->toIlType<void*>(),
                  types->toIlType<Index>());
+  DefineFunction("MemoryTranslationHelper", __FILE__, "0",
+                 reinterpret_cast<void*>(MemoryTranslationHelper),
+                 types->toIlType<void*>(),
+                 4,
+                 types->toIlType<void*>(),
+                 types->toIlType<uint32_t>(),
+                 types->toIlType<uint64_t>(),
+                 types->toIlType<uint32_t>());
 }
 
 bool FunctionBuilder::buildIL() {
@@ -481,6 +498,30 @@ void FunctionBuilder::EmitIntRemainder(TR::IlBuilder* b) {
 }
 
 template <typename T>
+TR::IlValue* FunctionBuilder::EmitMemoryPreAccess(TR::IlBuilder* b, const uint8_t** pc) {
+  auto th_addr = b->ConstAddress(thread_);
+  auto mem_id = b->ConstInt32(ReadU32(pc));
+  auto offset = b->ConstInt64(static_cast<uint64_t>(ReadU32(pc)));
+
+  auto address = b->Call("MemoryTranslationHelper",
+                         4,
+                         th_addr,
+                         mem_id,
+                         b->Add(b->UnsignedConvertTo(Int64, Pop(b, "i32")), offset),
+                         b->ConstInt32(sizeof(T)));
+
+  TR::IlBuilder* trap_handler = nullptr;
+
+  b->IfThen(&trap_handler,
+  b->       EqualTo(address, b->ConstAddress(nullptr)));
+
+  trap_handler->Return(
+  trap_handler->       Const(static_cast<Result_t>(interp::Result::TrapMemoryAccessOutOfBounds)));
+
+  return address;
+}
+
+template <typename T>
 TR::IlValue* FunctionBuilder::CalculateShiftAmount(TR::IlBuilder* b, TR::IlValue* amount) {
   return b->UnsignedConvertTo(Int32,
          b->                  And(amount, b->Const(static_cast<T>(sizeof(T) * 8 - 1))));
@@ -651,6 +692,30 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       b->     ConstInt32(func_index));
       break;
     }
+
+    case Opcode::I32Load:
+      Push(b,
+           "i32",
+      b->  LoadAt(typeDictionary()->PointerTo(Int32), EmitMemoryPreAccess<int32_t>(b, &pc)));
+      break;
+
+    case Opcode::I64Load:
+      Push(b,
+           "i64",
+      b->  LoadAt(typeDictionary()->PointerTo(Int64), EmitMemoryPreAccess<int64_t>(b, &pc)));
+      break;
+
+    case Opcode::F32Load:
+      Push(b,
+           "f32",
+      b->  LoadAt(typeDictionary()->PointerTo(Float), EmitMemoryPreAccess<float>(b, &pc)));
+      break;
+
+    case Opcode::F64Load:
+      Push(b,
+           "f64",
+      b->  LoadAt(typeDictionary()->PointerTo(Double), EmitMemoryPreAccess<double>(b, &pc)));
+      break;
 
     case Opcode::I32Add:
       EmitBinaryOp<int32_t>(b, [&](TR::IlValue* lhs, TR::IlValue* rhs) {

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -100,6 +100,9 @@ class FunctionBuilder : public TR::MethodBuilder {
   template <typename T>
   void EmitIntRemainder(TR::IlBuilder* b);
 
+  template <typename T>
+  TR::IlValue* EmitMemoryPreAccess(TR::IlBuilder* b, const uint8_t** pc);
+
   template <typename>
   TR::IlValue* CalculateShiftAmount(TR::IlBuilder* b, TR::IlValue* amount);
 
@@ -110,6 +113,8 @@ class FunctionBuilder : public TR::MethodBuilder {
   static Result_t CallIndirectHelper(wabt::interp::Thread* th, Index table_index, Index sig_index, Index entry_index, uint8_t* current_pc);
 
   static void CallHostHelper(wabt::interp::Thread* th, Index func_index);
+
+  static void* MemoryTranslationHelper(interp::Thread* th, uint32_t memory_id, uint64_t address, uint32_t size);
 
   std::vector<BytecodeWorkItem> workItems_;
 

--- a/test/jit/load.txt
+++ b/test/jit/load.txt
@@ -1,0 +1,298 @@
+;;; TOOL: run-interp-jit
+(module
+  (memory 1)
+
+  (func $i32_load (param i32) (result i32)
+    get_local 0
+    i32.load)
+
+  (func $i32_load_off (param i32) (result i32)
+    get_local 0
+    i32.load offset=4)
+
+  (func (export "test_i32_load_1") (result i32)
+    i32.const 0
+    i32.const 0xff00ff00
+    i32.store
+    i32.const 0
+    call $i32_load)
+
+  (func (export "test_i32_load_2") (result i32)
+    i32.const 0xfffc
+    i32.const 0xff00ff00
+    i32.store
+    i32.const 0xfffc
+    call $i32_load)
+
+  (func (export "test_i32_load_3") (result i32)
+    i32.const 4
+    i32.const 0x00ff00ff
+    i32.store
+    i32.const 0
+    call $i32_load_off)
+
+  (func (export "test_i32_load_4") (result i32)
+    i32.const 0xfffc
+    i32.const 0x00ff00ff
+    i32.store
+    i32.const 0xfff8
+    call $i32_load_off)
+
+  (func (export "test_i32_load_5") (result i32)
+    i32.const 3
+    i32.const 0xaabbccdd
+    i32.store
+    i32.const 3
+    call $i32_load)
+
+  (func (export "test_i32_load_6") (result i32)
+    i32.const 0x10000
+    call $i32_load)
+
+  (func (export "test_i32_load_7") (result i32)
+    i32.const 0xfffd
+    call $i32_load)
+
+  (func (export "test_i32_load_8") (result i32)
+    i32.const 0xfff9
+    call $i32_load_off)
+
+  (func (export "test_i32_load_9") (result i32)
+    i32.const 0xffffffff
+    call $i32_load)
+
+  (func (export "test_i32_load_10") (result i32)
+    i32.const 0xffffffff
+    call $i32_load_off)
+
+  (func $i64_load (param i32) (result i64)
+    get_local 0
+    i64.load)
+
+  (func $i64_load_off (param i32) (result i64)
+    get_local 0
+    i64.load offset=8)
+
+  (func (export "test_i64_load_1") (result i64)
+    i32.const 0
+    i64.const 0xff00ff00ff00ff00
+    i64.store
+    i32.const 0
+    call $i64_load)
+
+  (func (export "test_i64_load_2") (result i64)
+    i32.const 0xfff8
+    i64.const 0xff00ff00ff00ff00
+    i64.store
+    i32.const 0xfff8
+    call $i64_load)
+
+  (func (export "test_i64_load_3") (result i64)
+    i32.const 8
+    i64.const 0x00ff00ff00ff00ff
+    i64.store
+    i32.const 0
+    call $i64_load_off)
+
+  (func (export "test_i64_load_4") (result i64)
+    i32.const 0xfff8
+    i64.const 0x00ff00ff00ff00ff
+    i64.store
+    i32.const 0xfff0
+    call $i64_load_off)
+
+  (func (export "test_i64_load_5") (result i64)
+    i32.const 3
+    i64.const 0xaabbccddddccbbaa
+    i64.store
+    i32.const 3
+    call $i64_load)
+
+  (func (export "test_i64_load_6") (result i64)
+    i32.const 0x10000
+    call $i64_load)
+
+  (func (export "test_i64_load_7") (result i64)
+    i32.const 0xfff9
+    call $i64_load)
+
+  (func (export "test_i64_load_8") (result i64)
+    i32.const 0xfff1
+    call $i64_load_off)
+
+  (func (export "test_i64_load_9") (result i64)
+    i32.const 0xffffffff
+    call $i64_load)
+
+  (func (export "test_i64_load_10") (result i64)
+    i32.const 0xffffffff
+    call $i64_load_off)
+
+  (func $f32_load (param i32) (result f32)
+    get_local 0
+    f32.load)
+
+  (func $f32_load_off (param i32) (result f32)
+    get_local 0
+    f32.load offset=4)
+
+  (func (export "test_f32_load_1") (result f32)
+    i32.const 0
+    f32.const -4.5
+    f32.store
+    i32.const 0
+    call $f32_load)
+
+  (func (export "test_f32_load_2") (result f32)
+    i32.const 0xfffc
+    f32.const -4.5
+    f32.store
+    i32.const 0xfffc
+    call $f32_load)
+
+  (func (export "test_f32_load_3") (result f32)
+    i32.const 4
+    f32.const 4.5
+    f32.store
+    i32.const 0
+    call $f32_load_off)
+
+  (func (export "test_f32_load_4") (result f32)
+    i32.const 0xfffc
+    f32.const 4.5
+    f32.store
+    i32.const 0xfff8
+    call $f32_load_off)
+
+  (func (export "test_f32_load_5") (result f32)
+    i32.const 3
+    f32.const -inf
+    f32.store
+    i32.const 3
+    call $f32_load)
+
+  (func (export "test_f32_load_6") (result f32)
+    i32.const 0x10000
+    call $f32_load)
+
+  (func (export "test_f32_load_7") (result f32)
+    i32.const 0xfffd
+    call $f32_load)
+
+  (func (export "test_f32_load_8") (result f32)
+    i32.const 0xfff9
+    call $f32_load_off)
+
+  (func (export "test_f32_load_9") (result f32)
+    i32.const 0xffffffff
+    call $f32_load)
+
+  (func (export "test_f32_load_10") (result f32)
+    i32.const 0xffffffff
+    call $f32_load_off)
+
+  (func $f64_load (param i32) (result f64)
+    get_local 0
+    f64.load)
+
+  (func $f64_load_off (param i32) (result f64)
+    get_local 0
+    f64.load offset=8)
+
+  (func (export "test_f64_load_1") (result f64)
+    i32.const 0
+    f64.const -4.5
+    f64.store
+    i32.const 0
+    call $f64_load)
+
+  (func (export "test_f64_load_2") (result f64)
+    i32.const 0xfff8
+    f64.const -4.5
+    f64.store
+    i32.const 0xfff8
+    call $f64_load)
+
+  (func (export "test_f64_load_3") (result f64)
+    i32.const 8
+    f64.const 4.5
+    f64.store
+    i32.const 0
+    call $f64_load_off)
+
+  (func (export "test_f64_load_4") (result f64)
+    i32.const 0xfff8
+    f64.const 4.5
+    f64.store
+    i32.const 0xfff0
+    call $f64_load_off)
+
+  (func (export "test_f64_load_5") (result f64)
+    i32.const 3
+    f64.const -inf
+    f64.store
+    i32.const 3
+    call $f64_load)
+
+  (func (export "test_f64_load_6") (result f64)
+    i32.const 0x10000
+    call $f64_load)
+
+  (func (export "test_f64_load_7") (result f64)
+    i32.const 0xfff9
+    call $f64_load)
+
+  (func (export "test_f64_load_8") (result f64)
+    i32.const 0xfff1
+    call $f64_load_off)
+
+  (func (export "test_f64_load_9") (result f64)
+    i32.const 0xffffffff
+    call $f64_load)
+
+  (func (export "test_f64_load_10") (result f64)
+    i32.const 0xffffffff
+    call $f64_load_off)
+)
+(;; STDOUT ;;;
+test_i32_load_1() => i32:4278255360
+test_i32_load_2() => i32:4278255360
+test_i32_load_3() => i32:16711935
+test_i32_load_4() => i32:16711935
+test_i32_load_5() => i32:2864434397
+test_i32_load_6() => error: out of bounds memory access
+test_i32_load_7() => error: out of bounds memory access
+test_i32_load_8() => error: out of bounds memory access
+test_i32_load_9() => error: out of bounds memory access
+test_i32_load_10() => error: out of bounds memory access
+test_i64_load_1() => i64:18374966859414961920
+test_i64_load_2() => i64:18374966859414961920
+test_i64_load_3() => i64:71777214294589695
+test_i64_load_4() => i64:71777214294589695
+test_i64_load_5() => i64:12302652060373662634
+test_i64_load_6() => error: out of bounds memory access
+test_i64_load_7() => error: out of bounds memory access
+test_i64_load_8() => error: out of bounds memory access
+test_i64_load_9() => error: out of bounds memory access
+test_i64_load_10() => error: out of bounds memory access
+test_f32_load_1() => f32:-4.500000
+test_f32_load_2() => f32:-4.500000
+test_f32_load_3() => f32:4.500000
+test_f32_load_4() => f32:4.500000
+test_f32_load_5() => f32:-inf
+test_f32_load_6() => error: out of bounds memory access
+test_f32_load_7() => error: out of bounds memory access
+test_f32_load_8() => error: out of bounds memory access
+test_f32_load_9() => error: out of bounds memory access
+test_f32_load_10() => error: out of bounds memory access
+test_f64_load_1() => f64:-4.500000
+test_f64_load_2() => f64:-4.500000
+test_f64_load_3() => f64:4.500000
+test_f64_load_4() => f64:4.500000
+test_f64_load_5() => f64:-inf
+test_f64_load_6() => error: out of bounds memory access
+test_f64_load_7() => error: out of bounds memory access
+test_f64_load_8() => error: out of bounds memory access
+test_f64_load_9() => error: out of bounds memory access
+test_f64_load_10() => error: out of bounds memory access
+;;; STDOUT ;;)

--- a/test/jit/store.txt
+++ b/test/jit/store.txt
@@ -1,0 +1,386 @@
+;;; TOOL: run-interp-jit
+(module
+  (memory 1)
+
+  (func $i32_store (param i32) (param i32)
+    get_local 0
+    get_local 1
+    i32.store)
+
+  (func $i32_store_off (param i32) (param i32)
+    get_local 0
+    get_local 1
+    i32.store offset=4)
+
+  (func (export "test_i32_store_1") (result i32)
+    i32.const 0
+    i32.const 0
+    i32.store
+    i32.const 0
+    i32.const 0xff00ff00
+    call $i32_store
+    i32.const 0
+    i32.load)
+
+  (func (export "test_i32_store_2") (result i32)
+    i32.const 0xfffc
+    i32.const 0
+    i32.store
+    i32.const 0xfffc
+    i32.const 0xff00ff00
+    call $i32_store
+    i32.const 0xfffc
+    i32.load)
+
+  (func (export "test_i32_store_3") (result i32)
+    i32.const 4
+    i32.const 0
+    i32.store
+    i32.const 0
+    i32.const 0x00ff00ff
+    call $i32_store_off
+    i32.const 4
+    i32.load)
+
+  (func (export "test_i32_store_4") (result i32)
+    i32.const 0xfffc
+    i32.const 0
+    i32.store
+    i32.const 0xfff8
+    i32.const 0x00ff00ff
+    call $i32_store_off
+    i32.const 0xfffc
+    i32.load)
+
+  (func (export "test_i32_store_5") (result i32)
+    i32.const 3
+    i32.const 0
+    i32.store
+    i32.const 3
+    i32.const 0xaabbccdd
+    call $i32_store
+    i32.const 3
+    i32.load)
+
+  (func (export "test_i32_store_6")
+    i32.const 0x10000
+    i32.const 0
+    call $i32_store)
+
+  (func (export "test_i32_store_7")
+    i32.const 0xfffd
+    i32.const 0
+    call $i32_store)
+
+  (func (export "test_i32_store_8")
+    i32.const 0xfff9
+    i32.const 0
+    call $i32_store_off)
+
+  (func (export "test_i32_store_9")
+    i32.const 0xffffffff
+    i32.const 0
+    call $i32_store)
+
+  (func (export "test_i32_store_10")
+    i32.const 0xffffffff
+    i32.const 0
+    call $i32_store_off)
+
+  (func $i64_store (param i32) (param i64)
+    get_local 0
+    get_local 1
+    i64.store)
+
+  (func $i64_store_off (param i32) (param i64)
+    get_local 0
+    get_local 1
+    i64.store offset=8)
+
+  (func (export "test_i64_store_1") (result i64)
+    i32.const 0
+    i64.const 0
+    i64.store
+    i32.const 0
+    i64.const 0xff00ff00ff00ff00
+    call $i64_store
+    i32.const 0
+    i64.load)
+
+  (func (export "test_i64_store_2") (result i64)
+    i32.const 0xfff8
+    i64.const 0
+    i64.store
+    i32.const 0xfff8
+    i64.const 0xff00ff00ff00ff00
+    call $i64_store
+    i32.const 0xfff8
+    i64.load)
+
+  (func (export "test_i64_store_3") (result i64)
+    i32.const 8
+    i64.const 0
+    i64.store
+    i32.const 0
+    i64.const 0x00ff00ff00ff00ff
+    call $i64_store_off
+    i32.const 8
+    i64.load)
+
+  (func (export "test_i64_store_4") (result i64)
+    i32.const 0xfff8
+    i64.const 0
+    i64.store
+    i32.const 0xfff0
+    i64.const 0x00ff00ff00ff00ff
+    call $i64_store_off
+    i32.const 0xfff8
+    i64.load)
+
+  (func (export "test_i64_store_5") (result i64)
+    i32.const 3
+    i64.const 0
+    i64.store
+    i32.const 3
+    i64.const 0xaabbccddddccbbaa
+    call $i64_store
+    i32.const 3
+    i64.load)
+
+  (func (export "test_i64_store_6")
+    i32.const 0x10000
+    i64.const 0
+    call $i64_store)
+
+  (func (export "test_i64_store_7")
+    i32.const 0xfff9
+    i64.const 0
+    call $i64_store)
+
+  (func (export "test_i64_store_8")
+    i32.const 0xfff1
+    i64.const 0
+    call $i64_store_off)
+
+  (func (export "test_i64_store_9")
+    i32.const 0xffffffff
+    i64.const 0
+    call $i64_store)
+
+  (func (export "test_i64_store_10")
+    i32.const 0xffffffff
+    i64.const 0
+    call $i64_store_off)
+
+  (func $f32_store (param i32) (param f32)
+    get_local 0
+    get_local 1
+    f32.store)
+
+  (func $f32_store_off (param i32) (param f32)
+    get_local 0
+    get_local 1
+    f32.store offset=4)
+
+  (func (export "test_f32_store_1") (result f32)
+    i32.const 0
+    f32.const 0
+    f32.store
+    i32.const 0
+    f32.const -4.5
+    call $f32_store
+    i32.const 0
+    f32.load)
+
+  (func (export "test_f32_store_2") (result f32)
+    i32.const 0xfffc
+    f32.const 0
+    f32.store
+    i32.const 0xfffc
+    f32.const -4.5
+    call $f32_store
+    i32.const 0xfffc
+    f32.load)
+
+  (func (export "test_f32_store_3") (result f32)
+    i32.const 4
+    f32.const 0
+    f32.store
+    i32.const 0
+    f32.const 4.5
+    call $f32_store_off
+    i32.const 4
+    f32.load)
+
+  (func (export "test_f32_store_4") (result f32)
+    i32.const 0xfffc
+    f32.const 0
+    f32.store
+    i32.const 0xfff8
+    f32.const 4.5
+    call $f32_store_off
+    i32.const 0xfffc
+    f32.load)
+
+  (func (export "test_f32_store_5") (result f32)
+    i32.const 3
+    f32.const 0
+    f32.store
+    i32.const 3
+    f32.const -inf
+    call $f32_store
+    i32.const 3
+    f32.load)
+
+  (func (export "test_f32_store_6")
+    i32.const 0x10000
+    f32.const 0
+    call $f32_store)
+
+  (func (export "test_f32_store_7")
+    i32.const 0xfffd
+    f32.const 0
+    call $f32_store)
+
+  (func (export "test_f32_store_8")
+    i32.const 0xfff9
+    f32.const 0
+    call $f32_store_off)
+
+  (func (export "test_f32_store_9")
+    i32.const 0xffffffff
+    f32.const 0
+    call $f32_store)
+
+  (func (export "test_f32_store_10")
+    i32.const 0xffffffff
+    f32.const 0
+    call $f32_store_off)
+
+  (func $f64_store (param i32) (param f64)
+    get_local 0
+    get_local 1
+    f64.store)
+
+  (func $f64_store_off (param i32) (param f64)
+    get_local 0
+    get_local 1
+    f64.store offset=8)
+
+  (func (export "test_f64_store_1") (result f64)
+    i32.const 0
+    f64.const 0
+    f64.store
+    i32.const 0
+    f64.const -4.5
+    call $f64_store
+    i32.const 0
+    f64.load)
+
+  (func (export "test_f64_store_2") (result f64)
+    i32.const 0xfff8
+    f64.const 0
+    f64.store
+    i32.const 0xfff8
+    f64.const -4.5
+    call $f64_store
+    i32.const 0xfff8
+    f64.load)
+
+  (func (export "test_f64_store_3") (result f64)
+    i32.const 8
+    f64.const 0
+    f64.store
+    i32.const 0
+    f64.const 4.5
+    call $f64_store_off
+    i32.const 8
+    f64.load)
+
+  (func (export "test_f64_store_4") (result f64)
+    i32.const 0xfff8
+    f64.const 0
+    f64.store
+    i32.const 0xfff0
+    f64.const 4.5
+    call $f64_store_off
+    i32.const 0xfff8
+    f64.load)
+
+  (func (export "test_f64_store_5") (result f64)
+    i32.const 3
+    f64.const 0
+    f64.store
+    i32.const 3
+    f64.const -inf
+    call $f64_store
+    i32.const 3
+    f64.load)
+
+  (func (export "test_f64_store_6")
+    i32.const 0x10000
+    f64.const 0
+    call $f64_store)
+
+  (func (export "test_f64_store_7")
+    i32.const 0xfff9
+    f64.const 0
+    call $f64_store)
+
+  (func (export "test_f64_store_8")
+    i32.const 0xfff1
+    f64.const 0
+    call $f64_store_off)
+
+  (func (export "test_f64_store_9")
+    i32.const 0xffffffff
+    f64.const 0
+    call $f64_store)
+
+  (func (export "test_f64_store_10")
+    i32.const 0xffffffff
+    f64.const 0
+    call $f64_store_off)
+)
+(;; STDOUT ;;;
+test_i32_store_1() => i32:4278255360
+test_i32_store_2() => i32:4278255360
+test_i32_store_3() => i32:16711935
+test_i32_store_4() => i32:16711935
+test_i32_store_5() => i32:2864434397
+test_i32_store_6() => error: out of bounds memory access
+test_i32_store_7() => error: out of bounds memory access
+test_i32_store_8() => error: out of bounds memory access
+test_i32_store_9() => error: out of bounds memory access
+test_i32_store_10() => error: out of bounds memory access
+test_i64_store_1() => i64:18374966859414961920
+test_i64_store_2() => i64:18374966859414961920
+test_i64_store_3() => i64:71777214294589695
+test_i64_store_4() => i64:71777214294589695
+test_i64_store_5() => i64:12302652060373662634
+test_i64_store_6() => error: out of bounds memory access
+test_i64_store_7() => error: out of bounds memory access
+test_i64_store_8() => error: out of bounds memory access
+test_i64_store_9() => error: out of bounds memory access
+test_i64_store_10() => error: out of bounds memory access
+test_f32_store_1() => f32:-4.500000
+test_f32_store_2() => f32:-4.500000
+test_f32_store_3() => f32:4.500000
+test_f32_store_4() => f32:4.500000
+test_f32_store_5() => f32:-inf
+test_f32_store_6() => error: out of bounds memory access
+test_f32_store_7() => error: out of bounds memory access
+test_f32_store_8() => error: out of bounds memory access
+test_f32_store_9() => error: out of bounds memory access
+test_f32_store_10() => error: out of bounds memory access
+test_f64_store_1() => f64:-4.500000
+test_f64_store_2() => f64:-4.500000
+test_f64_store_3() => f64:4.500000
+test_f64_store_4() => f64:4.500000
+test_f64_store_5() => f64:-inf
+test_f64_store_6() => error: out of bounds memory access
+test_f64_store_7() => error: out of bounds memory access
+test_f64_store_8() => error: out of bounds memory access
+test_f64_store_9() => error: out of bounds memory access
+test_f64_store_10() => error: out of bounds memory access
+;;; STDOUT ;;)


### PR DESCRIPTION
This changeset implements loads and stores for i32, i64, f32, and f64 values and adds tests for these opcodes.