### PR TITLE
Print stack traces when a trap is encountered

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -1366,6 +1366,8 @@ Result Thread::Run(int num_instructions) {
             }
 
             if (meta->jit_fn) {
+              CHECK_TRAP(PushCall(pc));
+
               auto result = meta->jit_fn();
               if (result != Result::Ok) {
                 // We don't want to overwrite the pc of the JITted function if it traps
@@ -1373,6 +1375,8 @@ Result Thread::Run(int num_instructions) {
 
                 return result;
               }
+
+              PopCall();
             } else {
               CHECK_TRAP(PushCall(pc));
               GOTO(offset);

--- a/src/interp.h
+++ b/src/interp.h
@@ -529,6 +529,7 @@ class Thread {
 
  private:
   friend class wabt::jit::FunctionBuilder;
+  friend class Executor;
   const uint8_t* GetIstream() const { return env_->istream_->data.data(); }
 
   Memory* ReadMemory(const uint8_t** pc);
@@ -605,8 +606,11 @@ struct ExecResult {
   ExecResult(Result result, const TypedValues& values)
       : result(result), values(values) {}
 
+  void PrintCallStack(Stream*, Environment*);
+
   Result result = Result::Ok;
   TypedValues values;
+  std::vector<IstreamOffset> call_stack;
 };
 
 class Executor {

--- a/src/interp.h
+++ b/src/interp.h
@@ -252,6 +252,9 @@ struct DefinedFunc : Func {
 
   static bool classof(const Func* func) { return !func->is_host; }
 
+  std::string dbg_name_ = "???";
+  bool has_dbg_name_ = false;
+
   IstreamOffset offset;
   Index local_decl_count;
   Index local_count;

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -40,7 +40,7 @@ class FunctionBuilder : public TR::MethodBuilder {
    * @param type is the name of the field in the Value union corresponding to the type of the value being pushed
    * @param value is the IlValue representing the value being pushed
    */
-  void Push(TR::IlBuilder* b, const char* type, TR::IlValue* value);
+  void Push(TR::IlBuilder* b, const char* type, TR::IlValue* value, const uint8_t* pc);
 
   /**
    * @brief Generate pop from the interpreter stack
@@ -89,19 +89,23 @@ class FunctionBuilder : public TR::MethodBuilder {
   TR::IlValue* Const(TR::IlBuilder* b, const interp::TypedValue* v) const;
 
   template <typename T, typename TResult = T, typename TOpHandler>
-  void EmitBinaryOp(TR::IlBuilder* b, TOpHandler h);
+  void EmitBinaryOp(TR::IlBuilder* b, const uint8_t* pc, TOpHandler h);
 
   template <typename T, typename TResult = T, typename TOpHandler>
-  void EmitUnaryOp(TR::IlBuilder* b, TOpHandler h);
+  void EmitUnaryOp(TR::IlBuilder* b, const uint8_t* pc, TOpHandler h);
 
   template <typename T>
-  void EmitIntDivide(TR::IlBuilder* b);
+  void EmitIntDivide(TR::IlBuilder* b, const uint8_t* pc);
 
   template <typename T>
-  void EmitIntRemainder(TR::IlBuilder* b);
+  void EmitIntRemainder(TR::IlBuilder* b, const uint8_t* pc);
 
   template <typename T>
   TR::IlValue* EmitMemoryPreAccess(TR::IlBuilder* b, const uint8_t** pc);
+
+  void EmitTrap(TR::IlBuilder* b, TR::IlValue* result, const uint8_t* pc);
+  void EmitCheckTrap(TR::IlBuilder* b, TR::IlValue* result, const uint8_t* pc);
+  void EmitTrapIf(TR::IlBuilder* b, TR::IlValue* condition, TR::IlValue* result, const uint8_t* pc);
 
   template <typename>
   TR::IlValue* CalculateShiftAmount(TR::IlBuilder* b, TR::IlValue* amount);

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -34,4 +34,5 @@ options:
       --disable-jit                           Prevent just in time compilation
       --trap-on-failed-comp                   Trap if a JIT compilation fails
       --jit-threshold=THRESHOLD               Number of calls after which to JIT compile a function
+      --no-stack-trace                        Don't print a stack trace if a trap occurs
 ;;; STDOUT ;;)

--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -91,6 +91,7 @@ def main(args):
           options.enable_saturating_float_to_int,
       '--enable-threads': options.enable_threads,
       '--disable-jit': options.disable_jit,
+      '--no-stack-trace': not options.spec
   })
 
   wast_tool.verbose = options.print_cmd


### PR DESCRIPTION
This changeset introduces the ability for the interpreter to load debug names from WASM files and use them in order to print stack traces when trapping. This is mostly useful when debugging larger programs, since using the `--trace` option isn't feasible when doing so.