### PR TITLE
Update submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/dabeaz/ply
 [submodule "third_party/omr"]
 	path = third_party/omr
-	url = https://github.com/eclipse/omr.git
+	url = https://github.com/wasmjit-omr/omr.git


### PR DESCRIPTION
This changeset updates the submodule to point to the [wasmjit-omr fork of the OMR project](https://github.com/wasmjit-omr/omr). This will allow us to consume patches to OMR that have not yet been merged upstream. In addition, the submodule is also pointed to a newer commit.