### PR TITLE
Fix tool usage in some JIT tests

### DIFF
--- a/test/jit/br.txt
+++ b/test/jit/br.txt
@@ -1,4 +1,4 @@
-;;; TOOL: run-interp
+;;; TOOL: run-interp-jit
 (module
   (func $br_1_level (result i32)
     block

--- a/test/jit/callindirect.txt
+++ b/test/jit/callindirect.txt
@@ -1,4 +1,4 @@
-;;; TOOL: run-interp
+;;; TOOL: run-interp-jit
 (module
   (type $v_i (func (result i32)))
   (func $zero (type $v_i) 


### PR DESCRIPTION
Some JIT tests where using `run-interp` instead of `run-interp-jit`. This commit
fixes this.