### PR TITLE
Dispatch the JIT on indirect_call from interpreter

### DIFF
--- a/src/interp.h
+++ b/src/interp.h
@@ -341,6 +341,7 @@ struct HostModule : Module {
   std::unique_ptr<HostImportDelegate> import_delegate;
 };
 
+class Thread;
 class Environment {
  public:
   // Used to track and reset the state of the environment.
@@ -481,6 +482,8 @@ class Environment {
 
     JitMeta(DefinedFunc* wasm_fn) : wasm_fn(wasm_fn) {}
   };
+
+  bool TryJit(Thread* t, IstreamOffset offset, JITedFunction* fn);
 
   std::vector<std::unique_ptr<Module>> modules_;
   std::vector<FuncSignature> sigs_;


### PR DESCRIPTION
Previously, due to an oversight, the JIT was not being dispatched when
an indirect_call opcode was being handled from the interpreter. This
meant that indirect calls from the interpreter would not cause JIT
compilation of functions and would always run the called function in the
interpreter, even if a JITted version of that function was already
present.

Fixes #89.