### PR TITLE
Use debug names in FunctionBuilder

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -181,7 +181,7 @@ FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn
       pValueType_(types->PointerTo(types->LookupUnion("Value"))) {
   DefineLine(__LINE__);
   DefineFile(__FILE__);
-  DefineName("WASM_Function");
+  DefineName(fn->dbg_name_.c_str());
 
   DefineReturnType(types->toIlType<Result_t>());
 


### PR DESCRIPTION
This changeset extends previous changes made to allow loading of debug names for functions to use these debug names when setting the name in `FunctionBuilder`. These names are printed in various OMR logfiles, so knowing which function they refer to is very useful.

Note that for wasm files transformed without debug names (`--debug-names` must be passed to the `wat2wasm` tool), only exported functions will have proper names and all other functions will display as `???`. This is a fundamental limitation, since without this information there isn't really any way to identify which function is being compiled in a human-friendly way.