### PR TITLE
Fix host calls being unable to trap

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -1413,7 +1413,7 @@ Result Thread::Run(int num_instructions) {
         TRAP_UNLESS(env_->FuncSignaturesAreEqual(func->sig_index, sig_index),
                     IndirectCallSignatureMismatch);
         if (func->is_host) {
-          CallHost(cast<HostFunc>(func));
+          CHECK_TRAP(CallHost(cast<HostFunc>(func)));
         } else {
           auto* dfn = cast<DefinedFunc>(func);
           Environment::JITedFunction jit_fn;
@@ -1441,7 +1441,7 @@ Result Thread::Run(int num_instructions) {
 
       case Opcode::InterpCallHost: {
         Index func_index = ReadU32(&pc);
-        CallHost(cast<HostFunc>(env_->funcs_[func_index].get()));
+        CHECK_TRAP(CallHost(cast<HostFunc>(env_->funcs_[func_index].get())));
         break;
       }
 

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -124,7 +124,7 @@ class FunctionBuilder : public TR::MethodBuilder {
 
   static Result_t CallIndirectHelper(wabt::interp::Thread* th, Index table_index, Index sig_index, Index entry_index, uint8_t* current_pc);
 
-  static void CallHostHelper(wabt::interp::Thread* th, Index func_index);
+  static Result_t CallHostHelper(wabt::interp::Thread* th, Index func_index);
 
   static void* MemoryTranslationHelper(interp::Thread* th, uint32_t memory_id, uint64_t address, uint32_t size);
 


### PR DESCRIPTION
Due to an oversight in the interpreter code in vanilla WABT, the host
call helper function is capable of returning trap error codes but these
codes are ignored by the interpreter. This same oversight was then
replicated in JITted code for consistency. However, our macrobenchmark
requires that trapping from host calls work correctly, as the exit_group
syscall must trap to stop execution.