### PR TITLE
Fix problems building with newer C++ standard libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ set(OMR_THREAD ON CACHE BOOL "")
 set(OMR_TEST_COMPILER OFF CACHE BOOL "")
 set(OMR_OMRSIG OFF CACHE BOOL "")
 set(OMR_FVTEST OFF CACHE BOOL "")
-set(OMR_GLUE ${CMAKE_SOURCE_DIR}/example/glue)
 set(OMR_GC_SEGREGATED_HEAP OFF CACHE BOOL "")
 set(OMR_GC_MODRON_SCAVENGER OFF CACHE BOOL "")
 set(OMR_GC_MODRON_CONCURRENT_MARK OFF CACHE BOOL "")
@@ -271,6 +270,7 @@ function(add_omr)
   # files.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
 
+  add_subdirectory(third_party/omr/example/glue EXCLUDE_FROM_ALL)
   add_subdirectory(third_party/omr EXCLUDE_FROM_ALL)
 endfunction()
 

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -243,7 +243,7 @@ FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn
 }
 
 bool FunctionBuilder::buildIL() {
-  setVMState(new OMR::VirtualMachineState());
+  setVMState(new TR::VirtualMachineState());
 
   const uint8_t* istream = thread_->GetIstream();
 


### PR DESCRIPTION
Due to a problem in OMR, the previous version of OMR we were using no
longer builds correctly on machines with a newer C++ standard library.
The necessary changes have been made to allow wasmjit-omr to build with
a newer version of OMR which doesn't exhibit this problem.