### PR TITLE
Implement a virtual value stack for JIT-compiled functions

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(wabtjit STATIC
   type-dictionary.cc
   function-builder.cc
   wabtjit.cc
+  stack.cc
 )
 
 # Mark JitBuilder include directories as "system" include directories. For most compilers, this

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -243,119 +243,151 @@ FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn
 }
 
 bool FunctionBuilder::buildIL() {
-  setVMState(new TR::VirtualMachineState());
-
   const uint8_t* istream = thread_->GetIstream();
+  const uint8_t* pc = &istream[fn_->offset];
+  auto* state = new WabtState();
 
-  workItems_.emplace_back(OrphanBytecodeBuilder(0, const_cast<char*>(ReadOpcodeAt(&istream[fn_->offset]).GetName())),
-                          &istream[fn_->offset]);
+  SetUpLocals(this, &pc, &state->stack);
+  setVMState(state);
+
+  workItems_.emplace_back(OrphanBytecodeBuilder(0, const_cast<char*>(ReadOpcodeAt(pc).GetName())),
+                          pc);
   AppendBuilder(workItems_[0].builder);
 
   int32_t next_index;
 
   while ((next_index = GetNextBytecodeFromWorklist()) != -1) {
     auto& work_item = workItems_[next_index];
+    state = static_cast<WabtState*>(work_item.builder->vmState());
 
-    if (!Emit(work_item.builder, istream, work_item.pc))
+    if (!Emit(work_item.builder, istream, work_item.pc, state->stack))
       return false;
   }
 
   return true;
 }
 
-/**
- * @brief Generate push to the interpreter stack
- *
- * The generated code should be equivalent to:
- *
- * auto stack_top = *stack_top_addr;
- * stack_base_addr[stack_top] = value;
- * *stack_top_addr = stack_top + 1;
- */
-void FunctionBuilder::Push(TR::IlBuilder* b, const char* type, TR::IlValue* value, const uint8_t* pc) {
+void FunctionBuilder::SetUpLocals(TR::IlBuilder* b, const uint8_t** pc, VirtualStack* stack) {
+  // Add placeholders onto the virtual stack. These values should never be actually read, but will
+  // eventually be dropped using drop or drop_keep in the function epilogue.
+  for (size_t i = 0; i < fn_->param_and_local_types.size(); i++) {
+    stack->Push(nullptr);
+  }
+
+  if (fn_->local_count == 0) return;
+
+  Opcode opcode = ReadOpcode(pc);
+  TR_ASSERT_FATAL(opcode == Opcode::InterpAlloca, "Function with locals is missing alloca");
+
+  auto alloc_num = ReadU32(pc);
+  TR_ASSERT_FATAL(alloc_num == fn_->local_count,
+                  "Function has wrong alloca size (%u != %u)",
+                  alloc_num, fn_->local_count);
+
+  auto pInt32 = typeDictionary()->PointerTo(Int32);
+  auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
+  auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
+
+  auto* old_value_stack_top = b->LoadAt(pInt32, stack_top_addr);
+  auto* count = b->ConstInt32(fn_->local_count);
+  auto* stack_top = b->Add(old_value_stack_top, count);
+  b->StoreAt(stack_top_addr, stack_top);
+
+  TR::IlBuilder* overflow_handler = nullptr;
+
+  b->IfThen(&overflow_handler,
+  b->       UnsignedGreaterOrEqualTo(
+                stack_top,
+  b->           Const(static_cast<int32_t>(thread_->value_stack_.size()))));
+  overflow_handler->Return(
+  overflow_handler->    Const(static_cast<Result_t>(interp::Result::TrapValueStackExhausted)));
+
+  TR::IlBuilder* set_zero = nullptr;
+  b->ForLoopUp("i", &set_zero, old_value_stack_top, stack_top, b->Const(1));
+  set_zero->StoreIndirect("Value", "i64",
+  set_zero->              IndexAt(pValueType_, stack_base_addr,
+  set_zero->                      Load("i")),
+  set_zero->              ConstInt64(0));
+}
+
+void FunctionBuilder::TearDownLocals(TR::IlBuilder* b) {
+  if (fn_->param_and_local_types.size() == 0) return;
+
+  auto pInt32 = typeDictionary()->PointerTo(Int32);
+  auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
+
+  auto* old_stack_top = b->LoadAt(pInt32, stack_top_addr);
+  auto* count = b->ConstInt32(fn_->param_and_local_types.size());
+
+  b->StoreAt(stack_top_addr, b->Sub(old_stack_top, count));
+}
+
+uint32_t FunctionBuilder::GetLocalOffset(VirtualStack* stack, Type* type, uint32_t depth) {
+  uint32_t i = stack->Depth() - depth;
+  TR_ASSERT_FATAL(i < fn_->param_and_local_types.size(), "Attempt to access invalid local 0x%x", i);
+
+  if (type != nullptr) {
+    *type = fn_->param_and_local_types[i];
+  }
+
+  return fn_->param_and_local_types.size() - i;
+}
+
+void FunctionBuilder::MoveToPhysStack(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack, uint32_t depth) {
+  if (depth == 0)
+    return;
+
   auto pInt32 = typeDictionary()->PointerTo(Int32);
   auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
   auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
 
   auto* stack_top = b->LoadAt(pInt32, stack_top_addr);
+  auto* new_stack_top = b->Add(stack_top, b->ConstInt32(depth));
 
   EmitTrapIf(b,
-  b->        UnsignedGreaterOrEqualTo(
-                 stack_top,
-  b->            Const(static_cast<int32_t>(thread_->value_stack_.size()))),
+  b->        Or(
+  b->            UnsignedGreaterThan(
+                     new_stack_top,
+  b->                Const(static_cast<int32_t>(thread_->value_stack_.size()))),
+  b->            UnsignedLessThan(
+                     new_stack_top,
+                     stack_top)),
   b->        Const(static_cast<Result_t>(interp::Result::TrapValueStackExhausted)),
              pc);
 
-  b->StoreIndirect("Value", type,
-  b->              IndexAt(pValueType_,
-                           stack_base_addr,
-                           stack_top),
-                   value);
-  b->StoreAt(stack_top_addr,
-  b->        Add(
-                 stack_top,
-  b->            Const(1)));
-}
+  for (size_t i = 0; i < depth; i++) {
+    auto* val = stack->Pick(depth - i - 1);
 
-/**
- * @brief Generate pop from the interpreter stack
- *
- * The generated code should be equivalent to:
- *
- * auto new_stack_top = *stack_top_addr - 1;
- * *stack_top_addr = new_stack_top;
- * return stack_base_addr[new_stack_top];
- */
-TR::IlValue* FunctionBuilder::Pop(TR::IlBuilder* b, const char* type) {
-  auto pInt32 = typeDictionary()->PointerTo(Int32);
-  auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
-  auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
+    b->StoreIndirect("Value", TypeFieldName(val->getDataType()),
+    b->              IndexAt(pValueType_,
+                             stack_base_addr,
+    b->                      Add(stack_top, b->ConstInt32(i))),
+                     val);
+  }
 
-  auto* new_stack_top = b->Sub(
-                        b->    LoadAt(pInt32, stack_top_addr),
-                        b->    Const(1));
+  stack->DropKeep(depth, 0);
+
   b->StoreAt(stack_top_addr, new_stack_top);
-  return b->LoadIndirect("Value", type,
-         b->             IndexAt(pValueType_,
-                                 stack_base_addr,
-                                 new_stack_top));
 }
 
-/**
- * @brief Generate a drop-x from the interpreter stack, optionally keeping the top value
- *
- * The generated code should be equivalent to:
- *
- * auto stack_top = *stack_top_addr;
- * auto new_stack_top = stack_top - drop_count;
- *
- * if (keep_count == 1) {
- *   stack_base_addr[new_stack_top - 1] = stack_base_addr[stack_top - 1];
- * }
- *
- * *stack_top_addr = new_stack_top;
- */
-void FunctionBuilder::DropKeep(TR::IlBuilder* b, uint32_t drop_count, uint8_t keep_count) {
-  TR_ASSERT(keep_count <= 1, "Invalid keep count");
+void FunctionBuilder::MoveFromPhysStack(TR::IlBuilder* b, VirtualStack* stack, const std::vector<Type>& types) {
+  if (types.size() == 0)
+    return;
 
   auto pInt32 = typeDictionary()->PointerTo(Int32);
   auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
   auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
 
   auto* stack_top = b->LoadAt(pInt32, stack_top_addr);
-  auto* new_stack_top = b->Sub(stack_top, b->Const(static_cast<int32_t>(drop_count)));
+  auto* new_stack_top = b->Sub(stack_top, b->ConstInt32(types.size()));
 
-  if (keep_count == 1) {
-    auto* old_top_value = b->LoadAt(pValueType_,
-                          b->       IndexAt(pValueType_,
-                                            stack_base_addr,
-                          b->               Sub(stack_top, b->Const(1))));
+  for (size_t i = 0; i < types.size(); i++) {
+    auto* val = b->LoadIndirect("Value", TypeFieldName(types[i]),
+    b->                         IndexAt(pValueType_,
+                                        stack_base_addr,
+    b->                                 Add(new_stack_top, b->ConstInt32(i))));
 
-    b->StoreAt(
-    b->        IndexAt(pValueType_,
-                       stack_base_addr,
-    b->                Sub(new_stack_top, b->Const(1))),
-               old_top_value);
+    stack->Push(val);
   }
 
   b->StoreAt(stack_top_addr, new_stack_top);
@@ -368,7 +400,7 @@ void FunctionBuilder::DropKeep(TR::IlBuilder* b, uint32_t drop_count, uint8_t ke
  *
  * return &value_stack_[value_stack_top_ - depth];
  */
-TR::IlValue* FunctionBuilder::Pick(TR::IlBuilder* b, Index depth) {
+TR::IlValue* FunctionBuilder::PickPhys(TR::IlBuilder* b, uint32_t depth) {
   auto pInt32 = typeDictionary()->PointerTo(Int32);
   auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
   auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
@@ -427,6 +459,22 @@ const char* FunctionBuilder::TypeFieldName(Type t) const {
   }
 }
 
+const char* FunctionBuilder::TypeFieldName(TR::DataType dt) const {
+  switch (dt.getDataType()) {
+    case TR::Int32:
+      return TypeFieldName<int32_t>();
+    case TR::Int64:
+      return TypeFieldName<int64_t>();
+    case TR::Float:
+      return TypeFieldName<float>();
+    case TR::Double:
+      return TypeFieldName<double>();
+    default:
+      TR_ASSERT_FATAL(false, "Invalid primitive type %s", dt.toString());
+      return nullptr;
+  }
+}
+
 TR::IlValue* FunctionBuilder::Const(TR::IlBuilder* b, const interp::TypedValue* v) const {
   switch (v->type) {
     case Type::I32:
@@ -444,24 +492,24 @@ TR::IlValue* FunctionBuilder::Const(TR::IlBuilder* b, const interp::TypedValue* 
 }
 
 template <typename T, typename TResult, typename TOpHandler>
-void FunctionBuilder::EmitBinaryOp(TR::IlBuilder* b, const uint8_t* pc, TOpHandler h) {
-  auto* rhs = Pop(b, TypeFieldName<T>());
-  auto* lhs = Pop(b, TypeFieldName<T>());
+void FunctionBuilder::EmitBinaryOp(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack, TOpHandler h) {
+  auto* rhs = stack->Pop();
+  auto* lhs = stack->Pop();
 
-  Push(b, TypeFieldName<TResult>(), h(lhs, rhs), pc);
+  stack->Push(h(lhs, rhs));
 }
 
 template <typename T, typename TResult, typename TOpHandler>
-void FunctionBuilder::EmitUnaryOp(TR::IlBuilder* b, const uint8_t* pc, TOpHandler h) {
-  Push(b, TypeFieldName<TResult>(), h(Pop(b, TypeFieldName<T>())), pc);
+void FunctionBuilder::EmitUnaryOp(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack, TOpHandler h) {
+  stack->Push(h(stack->Pop()));
 }
 
 template <typename T>
-void FunctionBuilder::EmitIntDivide(TR::IlBuilder* b, const uint8_t* pc) {
+void FunctionBuilder::EmitIntDivide(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack) {
   static_assert(std::is_integral<T>::value,
                 "EmitIntDivide only works on integral types");
 
-  EmitBinaryOp<T>(b, pc, [&](TR::IlValue* dividend, TR::IlValue* divisor) {
+  EmitBinaryOp<T>(b, pc, stack, [&](TR::IlValue* dividend, TR::IlValue* divisor) {
     EmitTrapIf(b,
     b->        EqualTo(divisor, b->Const(static_cast<T>(0))),
     b->        Const(static_cast<Result_t>(interp::Result::TrapIntegerDivideByZero)),
@@ -479,11 +527,11 @@ void FunctionBuilder::EmitIntDivide(TR::IlBuilder* b, const uint8_t* pc) {
 }
 
 template <typename T>
-void FunctionBuilder::EmitIntRemainder(TR::IlBuilder* b, const uint8_t* pc) {
+void FunctionBuilder::EmitIntRemainder(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack) {
   static_assert(std::is_integral<T>::value,
                 "EmitIntRemainder only works on integral types");
 
-  EmitBinaryOp<T>(b, pc, [&](TR::IlValue* dividend, TR::IlValue* divisor) {
+  EmitBinaryOp<T>(b, pc, stack, [&](TR::IlValue* dividend, TR::IlValue* divisor) {
     EmitTrapIf(b,
     b->        EqualTo(divisor, b->Const(static_cast<T>(0))),
     b->        Const(static_cast<Result_t>(interp::Result::TrapIntegerDivideByZero)),
@@ -504,7 +552,7 @@ void FunctionBuilder::EmitIntRemainder(TR::IlBuilder* b, const uint8_t* pc) {
 }
 
 template <typename T>
-TR::IlValue* FunctionBuilder::EmitMemoryPreAccess(TR::IlBuilder* b, const uint8_t** pc) {
+TR::IlValue* FunctionBuilder::EmitMemoryPreAccess(TR::IlBuilder* b, const uint8_t** pc, VirtualStack* stack) {
   auto th_addr = b->ConstAddress(thread_);
   auto mem_id = b->ConstInt32(ReadU32(pc));
   auto offset = b->ConstInt64(static_cast<uint64_t>(ReadU32(pc)));
@@ -513,7 +561,7 @@ TR::IlValue* FunctionBuilder::EmitMemoryPreAccess(TR::IlBuilder* b, const uint8_
                          4,
                          th_addr,
                          mem_id,
-                         b->Add(b->UnsignedConvertTo(Int64, Pop(b, "i32")), offset),
+                         b->Add(b->UnsignedConvertTo(Int64, stack->Pop()), offset),
                          b->ConstInt32(sizeof(T)));
 
   EmitTrapIf(b,
@@ -568,10 +616,10 @@ TR::IlValue* FunctionBuilder::EmitIsNan<double>(TR::IlBuilder* b, TR::IlValue* v
 }
 
 template <typename ToType, typename FromType>
-void FunctionBuilder::EmitTruncation(TR::IlBuilder* b, const uint8_t* pc) {
+void FunctionBuilder::EmitTruncation(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack) {
   static_assert(std::is_floating_point<FromType>::value, "FromType in EmitTruncation call must be a floating point type");
 
-  auto* value = Pop(b, TypeFieldName<FromType>());
+  auto* value = stack->Pop();
 
   // TRAP_IF is NaN
   EmitTrapIf(b,
@@ -596,7 +644,7 @@ void FunctionBuilder::EmitTruncation(TR::IlBuilder* b, const uint8_t* pc) {
   auto* new_value = std::is_unsigned<ToType>::value ? b->UnsignedConvertTo(target_type, value)
                                                     : b->ConvertTo(target_type, value);
 
-  Push(b, TypeFieldName<ToType>(), new_value, pc);
+  stack->Push(new_value);
 }
 
 /**
@@ -608,12 +656,12 @@ void FunctionBuilder::EmitTruncation(TR::IlBuilder* b, const uint8_t* pc) {
  * the target type.
  */
 template <typename ToType, typename FromType>
-void FunctionBuilder::EmitUnsignedTruncation(TR::IlBuilder* b, const uint8_t* pc) {
+void FunctionBuilder::EmitUnsignedTruncation(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack) {
   static_assert(std::is_floating_point<FromType>::value, "FromType in EmitTruncation call must be a floating point type");
   static_assert(std::is_integral<ToType>::value, "ToType in EmitUnsignedTruncation call must be an integer type");
   static_assert(std::is_unsigned<ToType>::value, "ToType in EmitUnsignedTruncation call must be unsigned");
 
-  auto* value = Pop(b, TypeFieldName<FromType>());
+  auto* value = stack->Pop();
 
   // TRAP_IF is NaN
   EmitTrapIf(b,
@@ -634,7 +682,7 @@ void FunctionBuilder::EmitUnsignedTruncation(TR::IlBuilder* b, const uint8_t* pc
   auto* target_type = b->typeDictionary()->toIlType<ToType>();
   auto* new_value = b->UnsignedConvertTo(target_type, b->ConvertTo(Int64, value));
 
-  Push(b, TypeFieldName<ToType>(), new_value, pc);
+  stack->Push(new_value);
 }
 
 template <typename T>
@@ -645,18 +693,23 @@ TR::IlValue* FunctionBuilder::CalculateShiftAmount(TR::IlBuilder* b, TR::IlValue
 
 bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
                            const uint8_t* istream,
-                           const uint8_t* pc) {
+                           const uint8_t* pc,
+                           VirtualStack& stack) {
   Opcode opcode = ReadOpcode(&pc);
   TR_ASSERT(!opcode.IsInvalid(), "Invalid opcode");
 
   switch (opcode) {
     case Opcode::Select: {
-      TR::IlBuilder* true_path = nullptr;
-      TR::IlBuilder* false_path = nullptr;
+      auto* sel = stack.Pop();
+      auto* false_value = stack.Pop();
+      auto* true_value = stack.Pop();
 
-      b->IfThenElse(&true_path, &false_path, Pop(b, "i32"));
-      DropKeep(true_path, 1, 0);
-      DropKeep(false_path, 1, 1);
+      TR::IlBuilder* true_path = nullptr;
+
+      b->IfThen(&true_path, sel);
+      true_path->StoreOver(false_value, true_value);
+
+      stack.Push(false_value);
       break;
     }
 
@@ -681,6 +734,8 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
     // transformed into a BrUnless. So, there's no need to handle it.
 
     case Opcode::Return:
+      TearDownLocals(b);
+      MoveToPhysStack(b, pc, &stack, stack.Depth());
       b->Return(b->Const(static_cast<Result_t>(interp::Result::Ok)));
       return true;
 
@@ -689,26 +744,22 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       return true;
 
     case Opcode::I32Const: {
-      auto* val = b->ConstInt32(ReadU32(&pc));
-      Push(b, "i32", val, pc);
+      stack.Push(b->ConstInt32(ReadU32(&pc)));
       break;
     }
 
     case Opcode::I64Const: {
-      auto* val = b->ConstInt64(ReadU64(&pc));
-      Push(b, "i64", val, pc);
+      stack.Push(b->ConstInt64(ReadU64(&pc)));
       break;
     }
 
     case Opcode::F32Const: {
-      auto* val = b->ConstFloat(ReadUx<float>(&pc));
-      Push(b, "f32", val, pc);
+      stack.Push(b->ConstFloat(ReadUx<float>(&pc)));
       break;
     }
 
     case Opcode::F64Const: {
-      auto* val = b->ConstDouble(ReadUx<double>(&pc));
-      Push(b, "f64", val, pc);
+      stack.Push(b->ConstDouble(ReadUx<double>(&pc)));
       break;
     }
 
@@ -722,11 +773,11 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       if (g->mutable_) {
         // TODO(thomasbc): Can the address of a Global change at runtime?
         auto* addr = b->Const(&g->typed_value.value);
-        Push(b, type_field, b->LoadIndirect("Value", type_field, addr), pc);
+        stack.Push(b->LoadIndirect("Value", type_field, addr));
       } else {
         // With immutable globals, we can just substitute their actual value as
         // a constant at compile-time.
-        Push(b, type_field, Const(b, &g->typed_value), pc);
+        stack.Push(Const(b, &g->typed_value));
       }
 
       break;
@@ -742,41 +793,57 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       // TODO(thomasbc): Can the address of a Global change at runtime?
       auto* addr = b->Const(&g->typed_value.value);
 
-      b->StoreIndirect("Value", type_field, addr, Pop(b, type_field));
+      b->StoreIndirect("Value", type_field, addr, stack.Pop());
       break;
     }
 
     case Opcode::GetLocal: {
       // note: to work around JitBuilder's lack of support unions as value types,
       // just copy a field that's the size of the entire union
-      auto* local_addr = Pick(b, ReadU32(&pc));
-      Push(b, "i64", b->LoadIndirect("Value", "i64", local_addr), pc);
+      Type t;
+      uint32_t off = GetLocalOffset(&stack, &t, ReadU32(&pc));
+
+      stack.Push(b->LoadIndirect("Value", TypeFieldName(t), PickPhys(b, off)));
       break;
     }
 
     case Opcode::SetLocal: {
-      // see note for GetLocal
-      auto* value = Pop(b, "i64");
-      auto* local_addr = Pick(b, ReadU32(&pc));
-      b->StoreIndirect("Value", "i64", local_addr, value);
+      auto* value = stack.Pop();
+      uint32_t off = GetLocalOffset(&stack, nullptr, ReadU32(&pc));
+
+      b->StoreIndirect("Value", TypeFieldName(value->getDataType()), PickPhys(b, off), value);
       break;
     }
 
-    case Opcode::TeeLocal:
-      // see note for GetLocal
-      b->StoreIndirect("Value", "i64", Pick(b, ReadU32(&pc)), b->LoadIndirect("Value", "i64", Pick(b, 1)));
+    case Opcode::TeeLocal: {
+      auto* value = stack.Top();
+      uint32_t off = GetLocalOffset(&stack, nullptr, ReadU32(&pc));
+
+      b->StoreIndirect("Value", TypeFieldName(value->getDataType()), PickPhys(b, off), value);
       break;
+    }
 
     case Opcode::Call: {
       auto th_addr = b->ConstAddress(thread_);
-      auto offset = b->ConstInt32(ReadU32(&pc));
+      auto offset = ReadU32(&pc);
       auto current_pc = b->Const(pc);
 
+      auto meta_it = thread_->env()->jit_meta_.find(offset);
+      TR_ASSERT_FATAL(meta_it != thread_->env()->jit_meta_.end(),
+                      "Found call to unknown function at offset %u", offset);
+
+      auto* meta = &meta_it->second;
+      auto* sig = thread_->env()->GetFuncSignature(meta->wasm_fn->sig_index);
+
+      MoveToPhysStack(b, pc, &stack, sig->param_types.size());
+
       b->Store("result",
-      b->      Call("CallHelper", 3, th_addr, offset, current_pc));
+      b->      Call("CallHelper", 3, th_addr, b->ConstInt32(offset), current_pc));
 
       // Don't pass the pc since a trap in a called function should not update the thread's pc
       EmitCheckTrap(b, b->Load("result"), nullptr);
+
+      MoveFromPhysStack(b, &stack, sig->result_types);
 
       break;
     }
@@ -784,21 +851,30 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
     case Opcode::CallIndirect: {
       auto th_addr = b->ConstAddress(thread_);
       auto table_index = b->ConstInt32(ReadU32(&pc));
-      auto sig_index = b->ConstInt32(ReadU32(&pc));
-      auto entry_index = Pop(b, "i32");
+      auto sig_index = ReadU32(&pc);
+      auto entry_index = stack.Pop();
       auto current_pc = b->Const(pc);
 
+      auto* sig = thread_->env()->GetFuncSignature(sig_index);
+
+      MoveToPhysStack(b, pc, &stack, sig->param_types.size());
+
       b->Store("result",
-      b->      Call("CallIndirectHelper", 5, th_addr, table_index, sig_index, entry_index, current_pc));
+      b->      Call("CallIndirectHelper", 5, th_addr, table_index, b->ConstInt32(sig_index), entry_index, current_pc));
 
       // Don't pass the pc since a trap in a called function should not update the thread's pc
       EmitCheckTrap(b, b->Load("result"), nullptr);
+
+      MoveFromPhysStack(b, &stack, sig->result_types);
 
       break;
     }
 
     case Opcode::InterpCallHost: {
       Index func_index = ReadU32(&pc);
+      auto* sig = thread_->env()->GetFuncSignature(thread_->env()->GetFunc(func_index)->sig_index);
+
+      MoveToPhysStack(b, pc, &stack, sig->param_types.size());
 
       b->Store("result",
       b->      Call("CallHostHelper", 2,
@@ -807,263 +883,233 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 
       EmitCheckTrap(b, b->Load("result"), pc);
 
+      MoveFromPhysStack(b, &stack, sig->result_types);
+
       break;
     }
 
     case Opcode::I32Load8S: {
-      auto* addr = EmitMemoryPreAccess<int8_t>(b, &pc);
-      Push(b,
-           "i32",
-      b->  ConvertTo(Int32,
-      b->            LoadAt(typeDictionary()->PointerTo(Int8), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int8_t>(b, &pc, &stack);
+      stack.Push(
+      b-> ConvertTo(Int32,
+      b->           LoadAt(typeDictionary()->PointerTo(Int8), addr)));
       break;
     }
 
     case Opcode::I32Load8U: {
-      auto* addr = EmitMemoryPreAccess<int8_t>(b, &pc);
-      Push(b,
-           "i32",
-      b->  UnsignedConvertTo(Int32,
-      b->                    LoadAt(typeDictionary()->PointerTo(Int8), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int8_t>(b, &pc, &stack);
+      stack.Push(
+      b-> UnsignedConvertTo(Int32,
+      b->                   LoadAt(typeDictionary()->PointerTo(Int8), addr)));
       break;
     }
 
     case Opcode::I32Load16S: {
-      auto* addr = EmitMemoryPreAccess<int16_t>(b, &pc);
-      Push(b,
-           "i32",
-      b->  ConvertTo(Int32,
-      b->            LoadAt(typeDictionary()->PointerTo(Int16), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int16_t>(b, &pc, &stack);
+      stack.Push(
+      b-> ConvertTo(Int32,
+      b->           LoadAt(typeDictionary()->PointerTo(Int16), addr)));
       break;
     }
 
     case Opcode::I32Load16U: {
-      auto* addr = EmitMemoryPreAccess<int16_t>(b, &pc);
-      Push(b,
-           "i32",
-      b->  UnsignedConvertTo(Int32,
-      b->                    LoadAt(typeDictionary()->PointerTo(Int16), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int16_t>(b, &pc, &stack);
+      stack.Push(
+      b-> UnsignedConvertTo(Int32,
+      b->                   LoadAt(typeDictionary()->PointerTo(Int16), addr)));
       break;
     }
 
     case Opcode::I64Load8S: {
-      auto* addr = EmitMemoryPreAccess<int8_t>(b, &pc);
-      Push(b,
-           "i64",
-      b->  ConvertTo(Int64,
-      b->            LoadAt(typeDictionary()->PointerTo(Int8), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int8_t>(b, &pc, &stack);
+      stack.Push(
+      b-> ConvertTo(Int64,
+      b->           LoadAt(typeDictionary()->PointerTo(Int8), addr)));
       break;
     }
 
     case Opcode::I64Load8U: {
-      auto* addr = EmitMemoryPreAccess<int8_t>(b, &pc);
-      Push(b,
-           "i64",
-      b->  UnsignedConvertTo(Int64,
-      b->                    LoadAt(typeDictionary()->PointerTo(Int8), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int8_t>(b, &pc, &stack);
+      stack.Push(
+      b-> UnsignedConvertTo(Int64,
+      b->                   LoadAt(typeDictionary()->PointerTo(Int8), addr)));
       break;
     }
 
     case Opcode::I64Load16S: {
-      auto* addr = EmitMemoryPreAccess<int16_t>(b, &pc);
-      Push(b,
-           "i64",
-      b->  ConvertTo(Int64,
-      b->            LoadAt(typeDictionary()->PointerTo(Int16), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int16_t>(b, &pc, &stack);
+      stack.Push(
+      b-> ConvertTo(Int64,
+      b->           LoadAt(typeDictionary()->PointerTo(Int16), addr)));
       break;
     }
 
     case Opcode::I64Load16U: {
-      auto* addr = EmitMemoryPreAccess<int16_t>(b, &pc);
-      Push(b,
-           "i64",
-      b->  UnsignedConvertTo(Int64,
-      b->                    LoadAt(typeDictionary()->PointerTo(Int16), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int16_t>(b, &pc, &stack);
+      stack.Push(
+      b-> UnsignedConvertTo(Int64,
+      b->                   LoadAt(typeDictionary()->PointerTo(Int16), addr)));
       break;
     }
 
     case Opcode::I64Load32S: {
-      auto* addr = EmitMemoryPreAccess<int32_t>(b, &pc);
-      Push(b,
-           "i64",
-      b->  ConvertTo(Int64,
-      b->            LoadAt(typeDictionary()->PointerTo(Int32), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int32_t>(b, &pc, &stack);
+      stack.Push(
+      b-> ConvertTo(Int64,
+      b->           LoadAt(typeDictionary()->PointerTo(Int32), addr)));
       break;
     }
 
     case Opcode::I64Load32U: {
-      auto* addr = EmitMemoryPreAccess<int32_t>(b, &pc);
-      Push(b,
-           "i64",
-      b->  UnsignedConvertTo(Int64,
-      b->                    LoadAt(typeDictionary()->PointerTo(Int32), addr)),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int32_t>(b, &pc, &stack);
+      stack.Push(
+      b-> UnsignedConvertTo(Int64,
+      b->                   LoadAt(typeDictionary()->PointerTo(Int32), addr)));
       break;
     }
 
     case Opcode::I32Load: {
-      auto* addr = EmitMemoryPreAccess<int32_t>(b, &pc);
-      Push(b,
-           "i32",
-      b->  LoadAt(typeDictionary()->PointerTo(Int32), addr),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int32_t>(b, &pc, &stack);
+      stack.Push(b->LoadAt(typeDictionary()->PointerTo(Int32), addr));
       break;
     }
 
     case Opcode::I64Load: {
-      auto* addr = EmitMemoryPreAccess<int64_t>(b, &pc);
-      Push(b,
-           "i64",
-      b->  LoadAt(typeDictionary()->PointerTo(Int64), addr),
-           pc);
+      auto* addr = EmitMemoryPreAccess<int64_t>(b, &pc, &stack);
+      stack.Push(b->LoadAt(typeDictionary()->PointerTo(Int64), addr));
       break;
     }
 
     case Opcode::F32Load: {
-      auto* addr = EmitMemoryPreAccess<float>(b, &pc);
-      Push(b,
-           "f32",
-      b->  LoadAt(typeDictionary()->PointerTo(Float), addr),
-           pc);
+      auto* addr = EmitMemoryPreAccess<float>(b, &pc, &stack);
+      stack.Push(b->LoadAt(typeDictionary()->PointerTo(Float), addr));
       break;
     }
 
     case Opcode::F64Load: {
-      auto* addr = EmitMemoryPreAccess<double>(b, &pc);
-      Push(b,
-           "f64",
-      b->  LoadAt(typeDictionary()->PointerTo(Double), addr),
-           pc);
+      auto* addr = EmitMemoryPreAccess<double>(b, &pc, &stack);
+      stack.Push(b->LoadAt(typeDictionary()->PointerTo(Double), addr));
       break;
     }
 
     case Opcode::I32Store8: {
-      auto value = b->ConvertTo(Int8, Pop(b, "i32"));
-      b->StoreAt(EmitMemoryPreAccess<int8_t>(b, &pc), value);
+      auto value = b->ConvertTo(Int8, stack.Pop());
+      b->StoreAt(EmitMemoryPreAccess<int8_t>(b, &pc, &stack), value);
       break;
     }
 
     case Opcode::I32Store16: {
-      auto value = b->ConvertTo(Int16, Pop(b, "i32"));
-      b->StoreAt(EmitMemoryPreAccess<int16_t>(b, &pc), value);
+      auto value = b->ConvertTo(Int16, stack.Pop());
+      b->StoreAt(EmitMemoryPreAccess<int16_t>(b, &pc, &stack), value);
       break;
     }
 
     case Opcode::I64Store8: {
-      auto value = b->ConvertTo(Int8, Pop(b, "i64"));
-      b->StoreAt(EmitMemoryPreAccess<int8_t>(b, &pc), value);
+      auto value = b->ConvertTo(Int8, stack.Pop());
+      b->StoreAt(EmitMemoryPreAccess<int8_t>(b, &pc, &stack), value);
       break;
     }
 
     case Opcode::I64Store16: {
-      auto value = b->ConvertTo(Int16, Pop(b, "i64"));
-      b->StoreAt(EmitMemoryPreAccess<int16_t>(b, &pc), value);
+      auto value = b->ConvertTo(Int16, stack.Pop());
+      b->StoreAt(EmitMemoryPreAccess<int16_t>(b, &pc, &stack), value);
       break;
     }
 
     case Opcode::I64Store32: {
-      auto value = b->ConvertTo(Int32, Pop(b, "i64"));
-      b->StoreAt(EmitMemoryPreAccess<int32_t>(b, &pc), value);
+      auto value = b->ConvertTo(Int32, stack.Pop());
+      b->StoreAt(EmitMemoryPreAccess<int32_t>(b, &pc, &stack), value);
       break;
     }
 
     case Opcode::I32Store: {
-      auto value = Pop(b, "i32");
-      b->StoreAt(EmitMemoryPreAccess<int32_t>(b, &pc), value);
+      auto value = stack.Pop();
+      b->StoreAt(EmitMemoryPreAccess<int32_t>(b, &pc, &stack), value);
       break;
     }
 
     case Opcode::I64Store: {
-      auto value = Pop(b, "i64");
-      b->StoreAt(EmitMemoryPreAccess<int64_t>(b, &pc), value);
+      auto value = stack.Pop();
+      b->StoreAt(EmitMemoryPreAccess<int64_t>(b, &pc, &stack), value);
       break;
     }
 
     case Opcode::F32Store: {
-      auto value = Pop(b, "f32");
-      b->StoreAt(EmitMemoryPreAccess<float>(b, &pc), value);
+      auto value = stack.Pop();
+      b->StoreAt(EmitMemoryPreAccess<float>(b, &pc, &stack), value);
       break;
     }
 
     case Opcode::F64Store: {
-      auto value = Pop(b, "f64");
-      b->StoreAt(EmitMemoryPreAccess<double>(b, &pc), value);
+      auto value = stack.Pop();
+      b->StoreAt(EmitMemoryPreAccess<double>(b, &pc, &stack), value);
       break;
     }
 
     case Opcode::I32Add:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Add(lhs, rhs);
       });
       break;
 
     case Opcode::I32Sub:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Sub(lhs, rhs);
       });
       break;
 
     case Opcode::I32Mul:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Mul(lhs, rhs);
       });
       break;
 
     case Opcode::I32DivS:
-      EmitIntDivide<int32_t>(b, pc);
+      EmitIntDivide<int32_t>(b, pc, &stack);
       break;
 
     case Opcode::I32RemS:
-      EmitIntRemainder<int32_t>(b, pc);
+      EmitIntRemainder<int32_t>(b, pc, &stack);
       break;
 
     case Opcode::I32And:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->And(lhs, rhs);
       });
       break;
 
     case Opcode::I32Or:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Or(lhs, rhs);
       });
       break;
 
     case Opcode::I32Xor:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Xor(lhs, rhs);
       });
       break;
 
     case Opcode::I32Shl:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->ShiftL(lhs, CalculateShiftAmount<int32_t>(b, rhs));
       });
       break;
 
     case Opcode::I32ShrS:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->ShiftR(lhs, CalculateShiftAmount<int32_t>(b, rhs));
       });
       break;
 
     case Opcode::I32ShrU:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedShiftR(lhs, CalculateShiftAmount<int32_t>(b, rhs));
       });
       break;
 
     case Opcode::I32Rotl:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         auto* amount = CalculateShiftAmount<int32_t>(b, rhs);
 
         return b->Or(
@@ -1073,7 +1119,7 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       break;
 
     case Opcode::I32Rotr:
-      EmitBinaryOp<int32_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         auto* amount = CalculateShiftAmount<int32_t>(b, rhs);
 
         return b->Or(
@@ -1083,135 +1129,135 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       break;
 
     case Opcode::I32Eqz:
-      EmitUnaryOp<int32_t, int>(b, pc, [&](TR::IlValue* val) {
+      EmitUnaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* val) {
         return b->EqualTo(val, b->ConstInt32(0));
       });
       break;
 
     case Opcode::I32Eq:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->EqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I32Ne:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->NotEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I32LtS:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->LessThan(lhs, rhs);
       });
       break;
 
     case Opcode::I32LtU:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedLessThan(lhs, rhs);
       });
       break;
 
     case Opcode::I32GtS:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->GreaterThan(lhs, rhs);
       });
       break;
 
     case Opcode::I32GtU:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedGreaterThan(lhs, rhs);
       });
       break;
 
     case Opcode::I32LeS:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->LessOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I32LeU:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedLessOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I32GeS:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->GreaterOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I32GeU:
-      EmitBinaryOp<int32_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int32_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedGreaterOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I64Add:
-        EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
           return b->Add(lhs, rhs);
         });
         break;
 
     case Opcode::I64Sub:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Sub(lhs, rhs);
       });
       break;
 
     case Opcode::I64Mul:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Mul(lhs, rhs);
       });
       break;
 
     case Opcode::I64DivS:
-      EmitIntDivide<int64_t>(b, pc);
+      EmitIntDivide<int64_t>(b, pc, &stack);
       break;
 
     case Opcode::I64RemS:
-      EmitIntRemainder<int64_t>(b, pc);
+      EmitIntRemainder<int64_t>(b, pc, &stack);
       break;
 
     case Opcode::I64And:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->And(lhs, rhs);
       });
       break;
 
     case Opcode::I64Or:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Or(lhs, rhs);
       });
       break;
 
     case Opcode::I64Xor:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Xor(lhs, rhs);
       });
       break;
 
     case Opcode::I64Shl:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->ShiftL(lhs, CalculateShiftAmount<int64_t>(b, rhs));
       });
       break;
 
     case Opcode::I64ShrS:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->ShiftR(lhs, CalculateShiftAmount<int64_t>(b, rhs));
       });
       break;
 
     case Opcode::I64ShrU:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedShiftR(lhs, CalculateShiftAmount<int64_t>(b, rhs));
       });
       break;
 
     case Opcode::I64Rotl:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         auto* amount = CalculateShiftAmount<int64_t>(b, rhs);
 
         return b->Or(
@@ -1221,7 +1267,7 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       break;
 
     case Opcode::I64Rotr:
-      EmitBinaryOp<int64_t>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         auto* amount = CalculateShiftAmount<int64_t>(b, rhs);
 
         return b->Or(
@@ -1231,73 +1277,73 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       break;
 
     case Opcode::I64Eqz:
-      EmitUnaryOp<int64_t, int>(b, pc, [&](TR::IlValue* val) {
+      EmitUnaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* val) {
         return b->EqualTo(val, b->ConstInt64(0));
       });
       break;
 
     case Opcode::I64Eq:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->EqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I64Ne:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->NotEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I64LtS:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->LessThan(lhs, rhs);
       });
       break;
 
     case Opcode::I64LtU:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedLessThan(lhs, rhs);
       });
       break;
 
     case Opcode::I64GtS:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->GreaterThan(lhs, rhs);
       });
       break;
 
     case Opcode::I64GtU:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedGreaterThan(lhs, rhs);
       });
       break;
 
     case Opcode::I64LeS:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->LessOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I64LeU:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedLessOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I64GeS:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->GreaterOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I64GeU:
-      EmitBinaryOp<int64_t, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<int64_t, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->UnsignedGreaterOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::F32Abs:
-      EmitUnaryOp<float>(b, pc, [&](TR::IlValue* value) {
+      EmitUnaryOp<float>(b, pc, &stack, [&](TR::IlValue* value) {
         auto* return_value = b->Copy(value);
 
         TR::IlBuilder* zero_path = nullptr;
@@ -1316,85 +1362,85 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       break;
 
     case Opcode::F32Neg:
-      EmitUnaryOp<float>(b, pc, [&](TR::IlValue* value) {
+      EmitUnaryOp<float>(b, pc, &stack, [&](TR::IlValue* value) {
         return b->Mul(value, b->ConstFloat(-1));
       });
       break;
 
     case Opcode::F32Sqrt:
-      EmitUnaryOp<float>(b, pc, [&](TR::IlValue* value) {
+      EmitUnaryOp<float>(b, pc, &stack, [&](TR::IlValue* value) {
         return b->Call("f32_sqrt", 1, value);
       });
       break;
 
     case Opcode::F32Add:
-      EmitBinaryOp<float>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Add(lhs, rhs);
       });
       break;
 
     case Opcode::F32Sub:
-      EmitBinaryOp<float>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Sub(lhs, rhs);
       });
       break;
 
     case Opcode::F32Mul:
-      EmitBinaryOp<float>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Mul(lhs, rhs);
       });
       break;
 
     case Opcode::F32Div:
-      EmitBinaryOp<float>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Div(lhs, rhs);
       });
       break;
 
     case Opcode::F32Copysign:
-      EmitBinaryOp<float>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Call("f32_copysign", 2, lhs, rhs);
       });
       break;
 
     case Opcode::F32Eq:
-      EmitBinaryOp<float, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->EqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::F32Ne:
-      EmitBinaryOp<float, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->NotEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::F32Lt:
-      EmitBinaryOp<float, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->LessThan(lhs, rhs);
       });
       break;
 
     case Opcode::F32Le:
-      EmitBinaryOp<float, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->LessOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::F32Gt:
-      EmitBinaryOp<float, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->GreaterThan(lhs, rhs);
       });
       break;
 
     case Opcode::F32Ge:
-      EmitBinaryOp<float, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<float, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->GreaterOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::F64Abs:
-      EmitUnaryOp<double>(b, pc, [&](TR::IlValue* value) {
+      EmitUnaryOp<double>(b, pc, &stack, [&](TR::IlValue* value) {
         auto* return_value = b->Copy(value);
 
         TR::IlBuilder* zero_path = nullptr;
@@ -1413,298 +1459,239 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       break;
 
     case Opcode::F64Neg:
-      EmitUnaryOp<double>(b, pc, [&](TR::IlValue* value) {
+      EmitUnaryOp<double>(b, pc, &stack, [&](TR::IlValue* value) {
         return b->Mul(value, b->ConstDouble(-1));
       });
       break;
 
     case Opcode::F64Sqrt:
-      EmitUnaryOp<double>(b, pc, [&](TR::IlValue* value) {
+      EmitUnaryOp<double>(b, pc, &stack, [&](TR::IlValue* value) {
         return b->Call("f64_sqrt", 1, value);
       });
       break;
 
     case Opcode::F64Add:
-      EmitBinaryOp<double>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Add(lhs, rhs);
       });
       break;
 
     case Opcode::F64Sub:
-      EmitBinaryOp<double>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Sub(lhs, rhs);
       });
       break;
 
     case Opcode::F64Mul:
-      EmitBinaryOp<double>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Mul(lhs, rhs);
       });
       break;
 
     case Opcode::F64Div:
-      EmitBinaryOp<double>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Div(lhs, rhs);
       });
       break;
 
     case Opcode::F64Copysign:
-      EmitBinaryOp<double>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->Call("f64_copysign", 2, lhs, rhs);
       });
       break;
 
     case Opcode::F64Eq:
-      EmitBinaryOp<double, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->EqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::F64Ne:
-      EmitBinaryOp<double, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->NotEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::F64Lt:
-      EmitBinaryOp<double, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->LessThan(lhs, rhs);
       });
       break;
 
     case Opcode::F64Le:
-      EmitBinaryOp<double, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->LessOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::F64Gt:
-      EmitBinaryOp<double, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->GreaterThan(lhs, rhs);
       });
       break;
 
     case Opcode::F64Ge:
-      EmitBinaryOp<double, int>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+      EmitBinaryOp<double, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->GreaterOrEqualTo(lhs, rhs);
       });
       break;
 
     case Opcode::I32WrapI64: {
-      auto* value = Pop(b, "i64");
-      Push(b, "i32",
-      b->  ConvertTo(Int32, value),
-           pc);
+      stack.Push(b->ConvertTo(Int32, stack.Pop()));
       break;
     }
 
     case Opcode::I64ExtendSI32: {
-      auto* value = Pop(b, "i32");
-      Push(b, "i64",
-      b->  ConvertTo(Int64, value),
-           pc);
+      stack.Push(b->ConvertTo(Int64, stack.Pop()));
       break;
     }
 
     case Opcode::I64ExtendUI32: {
-      auto* value = Pop(b, "i32");
-      Push(b, "i64",
-      b->  UnsignedConvertTo(Int64, value),
-           pc);
+      stack.Push(b->UnsignedConvertTo(Int64, stack.Pop()));
       break;
     }
 
     case Opcode::F32DemoteF64: {
-      auto* value = Pop(b, "f64");
-      Push(b, "f32",
-      b->  ConvertTo(Float, value),
-           pc);
+      stack.Push(b->ConvertTo(Float, stack.Pop()));
       break;
     }
 
     case Opcode::F64PromoteF32: {
-      auto* value = Pop(b, "f32");
-      Push(b, "f64",
-      b->  ConvertTo(Double, value),
-           pc);
+      stack.Push(b->ConvertTo(Double, stack.Pop()));
       break;
     }
 
     case Opcode::I32Extend8S: {
-      auto* value = b->ConvertTo(Int32, b->ConvertTo(Int8, Pop(b, "i32")));
-      Push(b, "i32", value, pc);
+      stack.Push(b->ConvertTo(Int32, b->ConvertTo(Int8, stack.Pop())));
       break;
     }
 
     case Opcode::I32Extend16S: {
-      auto* value = b->ConvertTo(Int32, b->ConvertTo(Int16, Pop(b, "i32")));
-      Push(b, "i32", value, pc);
+      stack.Push(b->ConvertTo(Int32, b->ConvertTo(Int16, stack.Pop())));
       break;
     }
 
     case Opcode::I64Extend8S: {
-      auto* value = b->ConvertTo(Int32, b->ConvertTo(Int8, Pop(b, "i32")));
-      Push(b, "i32", value, pc);
+      stack.Push(b->ConvertTo(Int64, b->ConvertTo(Int8, stack.Pop())));
       break;
     }
 
     case Opcode::I64Extend16S: {
-      auto* value = b->ConvertTo(Int32, b->ConvertTo(Int16, Pop(b, "i32")));
-      Push(b, "i32", value, pc);
+      stack.Push(b->ConvertTo(Int64, b->ConvertTo(Int16, stack.Pop())));
       break;
     }
 
     case Opcode::I64Extend32S: {
-      auto* value = b->ConvertTo(Int64, b->ConvertTo(Int32, Pop(b, "i64")));
-      Push(b, "i64", value, pc);
+      stack.Push(b->ConvertTo(Int64, b->ConvertTo(Int32, stack.Pop())));
       break;
     }
 
     case Opcode::F32ConvertSI32: {
-      auto* value = b->ConvertTo(Float, Pop(b, "i32"));
-      Push(b, "f32", value, pc);
+      stack.Push(b->ConvertTo(Float, stack.Pop()));
       break;
     }
 
     case Opcode::F32ConvertUI32: {
-      auto* value = b->UnsignedConvertTo(Float, Pop(b, "i32"));
-      Push(b, "f32", value, pc);
+      stack.Push(b->UnsignedConvertTo(Float, stack.Pop()));
       break;
     }
 
     case Opcode::F32ConvertSI64: {
-      auto* value = b->ConvertTo(Float, Pop(b, "i64"));
-      Push(b, "f32", value, pc);
+      stack.Push(b->ConvertTo(Float, stack.Pop()));
       break;
     }
 
     case Opcode::F32ConvertUI64: {
-      auto* value = b->UnsignedConvertTo(Float, Pop(b, "i64"));
-      Push(b, "f32", value, pc);
+      stack.Push(b->UnsignedConvertTo(Float, stack.Pop()));
       break;
     }
 
     case Opcode::F64ConvertSI32: {
-      auto* value = b->ConvertTo(Double, Pop(b, "i32"));
-      Push(b, "f64", value, pc);
+      stack.Push(b->ConvertTo(Double, stack.Pop()));
       break;
     }
 
     case Opcode::F64ConvertUI32: {
-      auto* value = b->UnsignedConvertTo(Double, Pop(b, "i32"));
-      Push(b, "f64", value, pc);
+      stack.Push(b->UnsignedConvertTo(Double, stack.Pop()));
       break;
     }
 
     case Opcode::F64ConvertSI64: {
-      auto* value = b->ConvertTo(Double, Pop(b, "i64"));
-      Push(b, "f64", value, pc);
+      stack.Push(b->ConvertTo(Double, stack.Pop()));
       break;
     }
 
     case Opcode::F64ConvertUI64: {
-      auto* value = b->UnsignedConvertTo(Double, Pop(b, "i64"));
-      Push(b, "f64", value, pc);
+      stack.Push(b->UnsignedConvertTo(Double, stack.Pop()));
       break;
     }
 
     case Opcode::F32ReinterpretI32: {
-      auto* value = b->CoerceTo(Float, Pop(b, "i32"));
-      Push(b, "f32", value, pc);
+      stack.Push(b->CoerceTo(Float, stack.Pop()));
       break;
     }
 
     case Opcode::I32ReinterpretF32: {
-      auto* value = b->CoerceTo(Int32, Pop(b, "f32"));
-      Push(b, "i32", value, pc);
+      stack.Push(b->CoerceTo(Int32, stack.Pop()));
       break;
     }
 
     case Opcode::F64ReinterpretI64: {
-      auto* value = b->CoerceTo(Double, Pop(b, "i64"));
-      Push(b, "f64", value, pc);
+      stack.Push(b->CoerceTo(Double, stack.Pop()));
       break;
     }
 
     case Opcode::I64ReinterpretF64: {
-      auto* value = b->CoerceTo(Int64, Pop(b, "f64"));
-      Push(b, "i64", value, pc);
+      stack.Push(b->CoerceTo(Int64, stack.Pop()));
       break;
     }
 
     case Opcode::I32TruncSF32:
-      EmitTruncation<int32_t, float>(b, pc);
+      EmitTruncation<int32_t, float>(b, pc, &stack);
       break;
 
     case Opcode::I32TruncUF32:
-      EmitUnsignedTruncation<uint32_t, float>(b, pc);
+      EmitUnsignedTruncation<uint32_t, float>(b, pc, &stack);
       break;
 
     case Opcode::I32TruncSF64:
-      EmitTruncation<int32_t, double>(b, pc);
+      EmitTruncation<int32_t, double>(b, pc, &stack);
       break;
 
     case Opcode::I32TruncUF64:
-      EmitUnsignedTruncation<uint32_t, double>(b, pc);
+      EmitUnsignedTruncation<uint32_t, double>(b, pc, &stack);
       break;
 
     case Opcode::I64TruncSF32:
-      EmitTruncation<int64_t, float>(b, pc);
+      EmitTruncation<int64_t, float>(b, pc, &stack);
       break;
 
 //    UNSIGNED TYPE NOT HANDLED
 //    case Opcode::I64TruncUF32:
-//      EmitTruncation<uint64_t, float>(b, pc);
+//      EmitTruncation<uint64_t, float>(b, pc, &stack);
 //      break;
 
     case Opcode::I64TruncSF64:
-      EmitTruncation<int64_t, double>(b, pc);
+      EmitTruncation<int64_t, double>(b, pc, &stack);
       break;
 
 //    UNSIGNED TYPE NOT HANDLED
 //    case Opcode::I64TruncUF64:
-//      EmitTruncation<uint64_t, double>(b, pc);
+//      EmitTruncation<uint64_t, double>(b, pc, &stack);
 //      break;
-
-    case Opcode::InterpAlloca: {
-      auto pInt32 = typeDictionary()->PointerTo(Int32);
-      auto* stack_top_addr = b->ConstAddress(&thread_->value_stack_top_);
-      auto* stack_base_addr = b->ConstAddress(thread_->value_stack_.data());
-
-      auto* old_value_stack_top = b->LoadAt(pInt32, stack_top_addr);
-      auto* count = b->ConstInt32(ReadU32(&pc));
-      auto* stack_top =  b->Add(old_value_stack_top, count);
-      b->StoreAt(stack_top_addr, stack_top);
-
-      EmitTrapIf(b,
-      b->        UnsignedGreaterOrEqualTo(
-                     stack_top,
-      b->            Const(static_cast<int32_t>(thread_->value_stack_.size()))),
-      b->        Const(static_cast<Result_t>(interp::Result::TrapValueStackExhausted)),
-                 pc);
-
-      TR::IlBuilder* set_zero = nullptr;
-      b->ForLoopUp("i", &set_zero, old_value_stack_top, stack_top, b->Const(1));
-      set_zero->StoreIndirect("Value", "i64",
-      set_zero->              IndexAt(pValueType_, stack_base_addr,
-      set_zero->                      Load("i")),
-      set_zero->              ConstInt64(0));
-
-      break;
-    }
 
     case Opcode::InterpBrUnless: {
       auto target = &istream[ReadU32(&pc)];
-      auto condition = Pop(b, "i32");
-      auto it = std::find_if(workItems_.begin(), workItems_.end(), [&](const BytecodeWorkItem& b) {
-        return target == b.pc;
+      auto condition = stack.Pop();
+      auto it = std::find_if(workItems_.cbegin(), workItems_.cend(), [&](const BytecodeWorkItem& b) {
+        return pc == b.pc;
       });
-      if (it != workItems_.end()) {
-        b->IfCmpEqualZero(&it->builder, condition);
+      if (it != workItems_.cend()) {
+        b->IfCmpEqualZero(it->builder, condition);
       } else {
         int32_t next_index = static_cast<int32_t>(workItems_.size());
         workItems_.emplace_back(OrphanBytecodeBuilder(next_index,
-                                                      const_cast<char*>(ReadOpcodeAt(target).GetName())),
+                                                      const_cast<char*>(ReadOpcodeAt(pc).GetName())),
                                 target);
         b->IfCmpEqualZero(&workItems_[next_index].builder, condition);
       }
@@ -1712,13 +1699,13 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
     }
 
     case Opcode::Drop:
-      DropKeep(b, 1, 0);
+      stack.DropKeep(1, 0);
       break;
 
     case Opcode::InterpDropKeep: {
       uint32_t drop_count = ReadU32(&pc);
       uint8_t keep_count = *pc++;
-      DropKeep(b, drop_count, keep_count);
+      stack.DropKeep(drop_count, keep_count);
       break;
     }
 
@@ -1729,12 +1716,18 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       return false;
   }
 
-  int32_t next_index = static_cast<int32_t>(workItems_.size());
-
-  workItems_.emplace_back(OrphanBytecodeBuilder(next_index,
-                                                const_cast<char*>(ReadOpcodeAt(pc).GetName())),
-                          pc);
-  b->AddFallThroughBuilder(workItems_[next_index].builder);
+  auto it = std::find_if(workItems_.cbegin(), workItems_.cend(), [&](const BytecodeWorkItem& b) {
+    return pc == b.pc;
+  });
+  if (it != workItems_.cend()) {
+    b->AddFallThroughBuilder(it->builder);
+  } else {
+    int32_t next_index = static_cast<int32_t>(workItems_.size());
+    workItems_.emplace_back(OrphanBytecodeBuilder(next_index,
+                                                  const_cast<char*>(ReadOpcodeAt(pc).GetName())),
+                            pc);
+    b->AddFallThroughBuilder(workItems_[next_index].builder);
+  }
 
   return true;
 }

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -18,9 +18,10 @@
 #define FUNCTIONBUILDER_HPP
 
 #include "type-dictionary.h"
+#include "stack.h"
 #include "ilgen/BytecodeBuilder.hpp"
 #include "ilgen/MethodBuilder.hpp"
-#include "ilgen/VirtualMachineOperandStack.hpp"
+#include "ilgen/VirtualMachineState.hpp"
 
 #include "src/interp.h"
 
@@ -29,48 +30,23 @@
 namespace wabt {
 namespace jit {
 
+class WabtState : public TR::VirtualMachineState {
+public:
+  VirtualStack stack;
+
+  VirtualMachineState* MakeCopy() override {
+    return new WabtState(*this);
+  }
+
+  void MergeInto(TR::VirtualMachineState* other, TR::IlBuilder* b) override {
+    this->stack.MergeInto(&dynamic_cast<WabtState&>(*other).stack, b);
+  }
+};
+
 class FunctionBuilder : public TR::MethodBuilder {
  public:
   FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn, TypeDictionary* types);
   bool buildIL() override;
-
-  /**
-   * @brief Generate push to the interpreter stack
-   * @param b is the builder object used to generate the code
-   * @param type is the name of the field in the Value union corresponding to the type of the value being pushed
-   * @param value is the IlValue representing the value being pushed
-   */
-  void Push(TR::IlBuilder* b, const char* type, TR::IlValue* value, const uint8_t* pc);
-
-  /**
-   * @brief Generate pop from the interpreter stack
-   * @param b is the builder object used to generate the code
-   * @param type is the name of the field in the Value union corresponding to the type of the value being popped
-   * @return an IlValue representing the popped value
-   */
-  TR::IlValue* Pop(TR::IlBuilder* b, const char* type);
-
-  /**
-   * @brief Drop a number of values from the interpreter stack, optionally keeping the top value of the stack
-   * @param b is the builder object used to generate the code
-   * @param drop_count is the number of values to drop from the stack
-   * @param keep_count is 1 to keep the top value intact and 0 otherwise
-   */
-  void DropKeep(TR::IlBuilder* b, uint32_t drop_count, uint8_t keep_count);
-
-  /**
-   * @brief Generate load of pointer to a vlue on the interpreter stack by an index
-   * @param b is the builder object used to generate the code
-   * @param depth is the index from the top of the stack
-   * @return and IlValue representing a pointer to the value on the stack
-   *
-   * JitBuilder does not currently represent unions as value types. This a problem
-   * for this function because it cannot simply return an IlValue representing
-   * the union. As workaround, it will generate a load of the *base address* of
-   * the union, instead of loading the union directly. This behaviour differs
-   * from `Thread::Pick()` and users must take this into account.
-   */
-  TR::IlValue* Pick(TR::IlBuilder* b, Index depth);
 
  private:
   struct BytecodeWorkItem {
@@ -81,27 +57,35 @@ class FunctionBuilder : public TR::MethodBuilder {
       : builder(builder), pc(pc) {}
   };
 
+  void SetUpLocals(TR::IlBuilder* b, const uint8_t** pc, VirtualStack* stack);
+  void TearDownLocals(TR::IlBuilder* b);
+  uint32_t GetLocalOffset(VirtualStack* stack, Type* type, uint32_t depth);
+
+  void MoveToPhysStack(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack, uint32_t depth);
+  void MoveFromPhysStack(TR::IlBuilder* b, VirtualStack* stack, const std::vector<Type>& types);
+  TR::IlValue* PickPhys(TR::IlBuilder* b, uint32_t depth);
+
   template <typename T>
   const char* TypeFieldName() const;
-
   const char* TypeFieldName(Type t) const;
+  const char* TypeFieldName(TR::DataType dt) const;
 
   TR::IlValue* Const(TR::IlBuilder* b, const interp::TypedValue* v) const;
 
   template <typename T, typename TResult = T, typename TOpHandler>
-  void EmitBinaryOp(TR::IlBuilder* b, const uint8_t* pc, TOpHandler h);
+  void EmitBinaryOp(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack, TOpHandler h);
 
   template <typename T, typename TResult = T, typename TOpHandler>
-  void EmitUnaryOp(TR::IlBuilder* b, const uint8_t* pc, TOpHandler h);
+  void EmitUnaryOp(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack, TOpHandler h);
 
   template <typename T>
-  void EmitIntDivide(TR::IlBuilder* b, const uint8_t* pc);
+  void EmitIntDivide(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack);
 
   template <typename T>
-  void EmitIntRemainder(TR::IlBuilder* b, const uint8_t* pc);
+  void EmitIntRemainder(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack);
 
   template <typename T>
-  TR::IlValue* EmitMemoryPreAccess(TR::IlBuilder* b, const uint8_t** pc);
+  TR::IlValue* EmitMemoryPreAccess(TR::IlBuilder* b, const uint8_t** pc, VirtualStack* stack);
 
   void EmitTrap(TR::IlBuilder* b, TR::IlValue* result, const uint8_t* pc);
   void EmitCheckTrap(TR::IlBuilder* b, TR::IlValue* result, const uint8_t* pc);
@@ -111,9 +95,9 @@ class FunctionBuilder : public TR::MethodBuilder {
   TR::IlValue* EmitIsNan(TR::IlBuilder* b, TR::IlValue* value);
 
   template <typename ToType, typename FromType>
-  void EmitTruncation(TR::IlBuilder* b, const uint8_t* pc);
+  void EmitTruncation(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack);
   template <typename ToType, typename FromType>
-  void EmitUnsignedTruncation(TR::IlBuilder* b, const uint8_t* pc);
+  void EmitUnsignedTruncation(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack);
 
   template <typename>
   TR::IlValue* CalculateShiftAmount(TR::IlBuilder* b, TR::IlValue* amount);
@@ -136,7 +120,7 @@ class FunctionBuilder : public TR::MethodBuilder {
   TR::IlType* const valueType_;
   TR::IlType* const pValueType_;
 
-  bool Emit(TR::BytecodeBuilder* b, const uint8_t* istream, const uint8_t* pc);
+  bool Emit(TR::BytecodeBuilder* b, const uint8_t* istream, const uint8_t* pc, VirtualStack& stack);
 };
 
 }

--- a/src/jit/stack.cc
+++ b/src/jit/stack.cc
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 wasmjit-omr project participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stack.h"
+#include "infra/Assert.hpp"
+
+namespace wabt {
+namespace jit {
+
+void VirtualStack::Push(TR::IlValue* v) {
+  values_.push_back(v);
+}
+
+static TR::IlValue* CheckResult(TR::IlValue* v) {
+  TR_ASSERT(v, "Attempt to pick/pop an invalid value on the stack");
+  return v;
+}
+
+TR::IlValue* VirtualStack::Pop() {
+  TR_ASSERT(values_.size() > 0, "Attempt to pop off an empty stack");
+
+  auto* v = values_.back();
+  values_.pop_back();
+
+  return CheckResult(v);
+}
+
+void VirtualStack::DropKeep(size_t drop_count, size_t keep_count) {
+  TR_ASSERT(drop_count + keep_count >= drop_count && values_.size() > drop_count + keep_count,
+            "Attempt to drop_keep beyond the end of the stack");
+
+  values_.erase(values_.end() - drop_count - keep_count, values_.end() - keep_count);
+}
+
+TR::IlValue* VirtualStack::Pick(size_t i) {
+  TR_ASSERT(i < values_.size(), "Attempt to pick beyond the end of the stack");
+
+  return CheckResult(*(values_.end() - i - 1));
+}
+
+TR::IlValue* VirtualStack::PickBottom(size_t i) {
+  TR_ASSERT(i < values_.size(), "Attempt to pick beyond the end of the stack");
+
+  return CheckResult(*(values_.begin() + i));
+}
+
+void VirtualStack::MergeInto(const VirtualStack* other, TR::IlBuilder* b) {
+  TR_ASSERT(values_.size() == other->values_.size(),
+            "Attempt to merge divergent stacks: sizes don't match (%zu != %zu)",
+            values_.size(),
+            other->values_.size());
+
+  auto this_it = values_.begin();
+  auto other_it = other->values_.begin();
+
+  while (this_it != values_.end()) {
+    if (*this_it != *other_it) {
+      TR_ASSERT(*this_it && *other_it,
+                "Attempt to merge divergent stacks: element %zu is a placeholder",
+                this_it - values_.begin());
+      TR_ASSERT((*this_it)->getDataType() == (*other_it)->getDataType(),
+                "Attempt to merge divergent stacks: types don't match at element %zu (%s != %s)",
+                this_it - values_.begin(),
+                (*this_it)->getDataType()->toString(),
+                (*this_it)->getDataType()->toString());
+
+      b->StoreOver(*other_it, *this_it);
+    }
+
+    this_it++;
+    other_it++;
+  }
+}
+
+}
+}

--- a/src/jit/stack.h
+++ b/src/jit/stack.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 wasmjit-omr project participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JIT_STACK_HPP
+#define JIT_STACK_HPP
+
+#include <vector>
+
+#include "ilgen/IlBuilder.hpp"
+#include "ilgen/VirtualMachineState.hpp"
+
+namespace wabt {
+namespace jit {
+
+class VirtualStack : TR::VirtualMachineState {
+public:
+  void Push(TR::IlValue* v);
+  TR::IlValue* Pop();
+  void Drop() { DropKeep(1, 0); }
+  void DropKeep(size_t drop_count, size_t keep_count);
+
+  size_t Depth() { return values_.size(); }
+  TR::IlValue* Top() { return Pick(0); }
+  TR::IlValue* Pick(size_t i);
+  TR::IlValue* PickBottom(size_t i);
+
+  void MergeInto(const VirtualStack* other, TR::IlBuilder* b);
+
+  void MergeInto(TR::VirtualMachineState* other, TR::IlBuilder* b) override {
+    MergeInto(&dynamic_cast<VirtualStack&>(*other), b);
+  }
+
+  TR::VirtualMachineState* MakeCopy() override {
+    return new VirtualStack(*this);
+  }
+
+private:
+  std::vector<TR::IlValue*> values_;
+};
+
+}
+}
+
+#endif // JIT_STACK_HPP


### PR DESCRIPTION
This PR adds support for a custom virtual stack that should eliminate most unnecessary reads and writes to/from the value stack that were caused by the previous naive implementation (#24). This should hopefully give a considerable performance boost.