### PR TITLE
Split arithmetic opcode section of TURBO worksheet

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -292,6 +292,10 @@ void FunctionBuilder::Push(TR::IlBuilder* b, const char* type, TR::IlValue* valu
   b->            Const(1)));
 }
 
+void FunctionBuilder::PushI32(TR::IlBuilder* b, TR::IlValue* value, const uint8_t* pc) {
+  Push(b, "i32", value, pc);
+}
+
 /**
  * @brief Generate pop from the interpreter stack
  *
@@ -314,6 +318,10 @@ TR::IlValue* FunctionBuilder::Pop(TR::IlBuilder* b, const char* type) {
          b->             IndexAt(pValueType_,
                                  stack_base_addr,
                                  new_stack_top));
+}
+
+TR::IlValue* FunctionBuilder::PopI32(TR::IlBuilder* b) {
+  return Pop(b, "i32");
 }
 
 /**
@@ -991,7 +999,10 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
     }
 
     case Opcode::I32Add:
-      return false;
+      auto rhs = PopI32(b);
+      auto lhs = PopI32(b);
+      PushI32(b, b->Add(lhs, rhs), pc);
+      break;
 
     case Opcode::I32Sub:
       return false;
@@ -1315,16 +1326,10 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       break;
 
     case Opcode::F32Sub:
-      EmitBinaryOp<float>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
-        return b->Sub(lhs, rhs);
-      });
-      break;
+      return false;
 
     case Opcode::F32Mul:
-      EmitBinaryOp<float>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
-        return b->Mul(lhs, rhs);
-      });
-      break;
+      return false;
 
     case Opcode::F32Div:
       EmitBinaryOp<float>(b, pc, [&](TR::IlValue* lhs, TR::IlValue* rhs) {

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -39,8 +39,19 @@ class FunctionBuilder : public TR::MethodBuilder {
    * @param b is the builder object used to generate the code
    * @param type is the name of the field in the Value union corresponding to the type of the value being pushed
    * @param value is the IlValue representing the value being pushed
+   * @param pc is a pointer the instruction performing the push
+   *
+   * If the push results in a stack overflow as trap condition is generated for the instruction pointed to by `pc`.
    */
   void Push(TR::IlBuilder* b, const char* type, TR::IlValue* value, const uint8_t* pc);
+
+  /**
+   * @brief Overload of `Push()` for 32-bit integer values
+   * @param b is the builder object used to generate the code
+   * @param value is the IlValue representing the value being pushed
+   * @param pc is a pointer the instruction performing the push
+   */
+  void PushI32(TR::IlBuilder* b, TR::IlValue* value, const uint8_t* pc);
 
   /**
    * @brief Generate pop from the interpreter stack
@@ -49,6 +60,13 @@ class FunctionBuilder : public TR::MethodBuilder {
    * @return an IlValue representing the popped value
    */
   TR::IlValue* Pop(TR::IlBuilder* b, const char* type);
+
+  /**
+   * @brief Overload of `Pop()` for 32-bit integer values
+   * @param b is the builder object used to generate the code
+   * @return an IlValue representing the popped value
+   */
+  TR::IlValue* PopI32(TR::IlBuilder* b);
 
   /**
    * @brief Drop a number of values from the interpreter stack, optionally keeping the top value of the stack


### PR DESCRIPTION
Instead of implementing i32.add, i32.sub, and i32.mul using Push() and
Pop(), the implementation of i32.add is provided and participants must
now only implement the other opcodes. To make implementation easier,
PopI32() and PushI32() are added to FunctionBuilder. Finally, another
exercise is added to implement f32.sub and f32.mul, following the
provided f32.add implementation that uses EmitBinaryOp().