### PR TITLE
Clarify "Where To Compile" exercise

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -1371,14 +1371,22 @@ Result Thread::Run(int num_instructions) {
       case Opcode::Call: {
         IstreamOffset offset = ReadU32(&pc);
 
+        // YOUR CODE HERE
+
+        // REPLACE `false` WITH CHECK OF `TryJit()` RETURN VALUE
         if (false) {
 
+          // REPLACE `true` WITH CHECK THAT VALUE RETURNED BY COMPILED BODY IS NOT `Result::Ok`
           if (true) {
+            // **DO NOT CHANGE ANYTHING HERE**
+
             // We don't want to overwrite the pc of the JITted function if it traps
             tpc.Reload();
 
             return result;
           }
+
+          // POP CALL STACK
 
         } else {
           CHECK_TRAP(PushCall(pc));

--- a/turbo.md
+++ b/turbo.md
@@ -326,6 +326,23 @@ these calls where the interpreter handles calls. When a program is about to
 call a function, the interpreter will invoke the JIT and, if compilation
 succeeds, call the entry point returned by the JIT.
 
+To correctly manage calls, the VM must keep track of the call stack at all times.
+For convenience, the `PushCall(const uint8_t* pc)` and `PopCall()` function are
+provided. `PushCall()` takes as an argument the `pc` of the call instruction and
+returns a status to indicate possible trap conditions due to a call stack
+overflow. `PopCall()` simply resets the interpreter's pc and takes no arguments
+and produces no return value.
+
+When the interpreter calls a JIT compiled function body, it is important to call
+both of the above functions before and after the JIT compiled function call.
+More precisely, the sequence of events must be:
+
+- push a new stack by calling `PushCall(pc)`, checking for a trap condition in the
+  returned value (`CHECK_TRAP()` macro can be used for this purpose)
+- call the JIT compiled function
+- check that the JIT compiled function returns `interp::Result::Ok`
+- pop the stack frame by calling `PopCall()`
+
 #### Your Task
 
 In [`src/interp.cc`](https://github.com/wasmjit-omr/wasmjit-omr/blob/42b8ae72308581eaff882626496ec1cf8dadff8f/src/interp.cc#L1371),
@@ -334,24 +351,32 @@ complete the WABT interpreter's handling of the
 body when successful.
 
 ```c++
-       case Opcode::Call: {
-         IstreamOffset offset = ReadU32(&pc);
+      case Opcode::Call: {
+        IstreamOffset offset = ReadU32(&pc);
 
-         if (false) {
+        // YOUR CODE HERE
 
-           if (true) {
-             // We don't want to overwrite the pc of the JITted function if it traps
-             tpc.Reload();
+        // REPLACE `false` WITH CHECK OF `TryJit()` RETURN VALUE
+        if (false) {
 
-             return result;
-           }
+          // REPLACE `true WITH CHECK THAT VALUE RETURNED BY COMPILED BODY IS NOT `Result::Ok`
+          if (true) {
+            // **DO NOT CHANGE ANYTHING HERE**
 
-         } else {
-           CHECK_TRAP(PushCall(pc));
-           GOTO(offset);
-         }
-         break;
-       }
+            // We don't want to overwrite the pc of the JITted function if it traps
+            tpc.Reload();
+
+            return result;
+          }
+
+          // POP CALL STACK
+
+        } else {
+          CHECK_TRAP(PushCall(pc));
+          GOTO(offset);
+        }
+        break;
+      }
 ```
 
 When the interpreter encounters a `Call` instruction, it proceeds as follows:


### PR DESCRIPTION
Comments are added to the incomplete code that describe where the code
written by participants must go and what it must do.

Also, a description of what `PushCall()` and `PopCall()` do and how to
use them is added to the "Background" section of the exercise.