### PR TITLE
Add JIT tests for the select opcode

### DIFF
--- a/test/jit/select.txt
+++ b/test/jit/select.txt
@@ -1,0 +1,88 @@
+;;; TOOL: run-interp-jit
+(module
+  (func $select_i32 (param i32) (result i32)
+    i32.const 0xdeadbeef
+    i32.const 0xcafebabe
+    get_local 0
+    select)
+
+  (func $select_i64 (param i32) (result i64)
+    i64.const 0xdeaddeaddeadbeef
+    i64.const 0xcafebabebabecafe
+    get_local 0
+    select)
+
+  (func $select_f32 (param i32) (result f32)
+    f32.const 3.141593
+    f32.const 1.618034
+    get_local 0
+    select)
+
+  (func $select_f64 (param i32) (result f64)
+    f64.const 3.141593
+    f64.const 1.618034
+    get_local 0
+    select)
+
+  (func (export "test_select_i32_0") (result i32)
+    i32.const 0
+    call $select_i32)
+
+  (func (export "test_select_i32_1") (result i32)
+    i32.const 1
+    call $select_i32)
+
+  (func (export "test_select_i32_2") (result i32)
+    i32.const 0xffffffff
+    call $select_i32)
+
+  (func (export "test_select_i64_0") (result i64)
+    i32.const 0
+    call $select_i64)
+
+  (func (export "test_select_i64_1") (result i64)
+    i32.const 1
+    call $select_i64)
+
+  (func (export "test_select_i64_2") (result i64)
+    i32.const 0xffffffff
+    call $select_i64)
+
+  (func (export "test_select_f32_0") (result f32)
+    i32.const 0
+    call $select_f32)
+
+  (func (export "test_select_f32_1") (result f32)
+    i32.const 1
+    call $select_f32)
+
+  (func (export "test_select_f32_2") (result f32)
+    i32.const 0xffffffff
+    call $select_f32)
+
+  (func (export "test_select_f64_0") (result f64)
+    i32.const 0
+    call $select_f64)
+
+  (func (export "test_select_f64_1") (result f64)
+    i32.const 1
+    call $select_f64)
+
+  (func (export "test_select_f64_2") (result f64)
+    i32.const 0xffffffff
+    call $select_f64)
+)
+(;; STDOUT ;;;
+test_select_i32_0() => i32:3405691582
+test_select_i32_1() => i32:3735928559
+test_select_i32_2() => i32:3735928559
+test_select_i64_0() => i64:14627333968085568254
+test_select_i64_1() => i64:16045725885737582319
+test_select_i64_2() => i64:16045725885737582319
+test_select_f32_0() => f32:1.618034
+test_select_f32_1() => f32:3.141593
+test_select_f32_2() => f32:3.141593
+test_select_f64_0() => f64:1.618034
+test_select_f64_1() => f64:3.141593
+test_select_f64_2() => f64:3.141593
+;;; STDOUT ;;)


### PR DESCRIPTION
Previously, the `select` opcode did not have any JIT tests. This was because it was added to the project very early on, before the test framework was fully set up. This PR adds some tests for this opcode, as it has recently caused some issues during development of the virtual stack changes.