### PR TITLE
Add JIT tests for integer conversion opcodes

### DIFF
--- a/test/jit/int_convert.txt
+++ b/test/jit/int_convert.txt
@@ -1,0 +1,81 @@
+;;; TOOL: run-interp-jit
+(module
+  (func $i32_wrap_i64 (param i64) (result i32)
+    get_local 0
+    i32.wrap/i64)
+
+  (func (export "test_i32_wrap_i64_0") (result i32)
+    i64.const 0
+    call $i32_wrap_i64)
+
+  (func (export "test_i32_wrap_i64_1") (result i32)
+    i64.const 0xffffffff
+    call $i32_wrap_i64)
+
+  (func (export "test_i32_wrap_i64_2") (result i32)
+    i64.const 0x1ffffffff
+    call $i32_wrap_i64)
+
+  (func (export "test_i32_wrap_i64_3") (result i32)
+    i64.const 0x100000000
+    call $i32_wrap_i64)
+
+  (func (export "test_i32_wrap_i64_4") (result i32)
+    i64.const 0xbeeeeeefbaadf00d
+    call $i32_wrap_i64)
+
+  (func $i64_extend_u_i32 (param i32) (result i64)
+    get_local 0
+    i64.extend_u/i32)
+
+  (func (export "test_i64_extend_u_i32_0") (result i64)
+    i32.const 0
+    call $i64_extend_u_i32)
+
+  (func (export "test_i64_extend_u_i32_1") (result i64)
+    i32.const 0x7fffffff
+    call $i64_extend_u_i32)
+
+  (func (export "test_i64_extend_u_i32_2") (result i64)
+    i32.const 0x80000000
+    call $i64_extend_u_i32)
+
+  (func (export "test_i64_extend_u_i32_3") (result i64)
+    i32.const 0xffffffff
+    call $i64_extend_u_i32)
+
+  (func $i64_extend_s_i32 (param i32) (result i64)
+    get_local 0
+    i64.extend_s/i32)
+
+  (func (export "test_i64_extend_s_i32_0") (result i64)
+    i32.const 0
+    call $i64_extend_s_i32)
+
+  (func (export "test_i64_extend_s_i32_1") (result i64)
+    i32.const 0x7fffffff
+    call $i64_extend_s_i32)
+
+  (func (export "test_i64_extend_s_i32_2") (result i64)
+    i32.const 0x80000000
+    call $i64_extend_s_i32)
+
+  (func (export "test_i64_extend_s_i32_3") (result i64)
+    i32.const 0xffffffff
+    call $i64_extend_s_i32)
+)
+(;; STDOUT ;;;
+test_i32_wrap_i64_0() => i32:0
+test_i32_wrap_i64_1() => i32:4294967295
+test_i32_wrap_i64_2() => i32:4294967295
+test_i32_wrap_i64_3() => i32:0
+test_i32_wrap_i64_4() => i32:3131961357
+test_i64_extend_u_i32_0() => i64:0
+test_i64_extend_u_i32_1() => i64:2147483647
+test_i64_extend_u_i32_2() => i64:2147483648
+test_i64_extend_u_i32_3() => i64:4294967295
+test_i64_extend_s_i32_0() => i64:0
+test_i64_extend_s_i32_1() => i64:2147483647
+test_i64_extend_s_i32_2() => i64:18446744071562067968
+test_i64_extend_s_i32_3() => i64:18446744073709551615
+;;; STDOUT ;;)


### PR DESCRIPTION
This PR adds extra JIT tests for the following opcodes covered by #92:

- `i32.wrap/i64`
- `i64.extend_u/i32`
- `i64.extend_s/i32`