### PR TITLE
Add JIT tests for floating-point conversion opcodes

### DIFF
--- a/test/jit/float_convert.txt
+++ b/test/jit/float_convert.txt
@@ -1,0 +1,114 @@
+;;; TOOL: run-interp-jit
+(module
+  (memory 1)
+
+  (func $f32_demote_f64 (param f64) (result f32)
+    get_local 0
+    f32.demote/f64)
+
+  (func (export "test_f32_demote_f64_0") (result f32)
+    f64.const 3.141593
+    call $f32_demote_f64)
+
+  (func (export "test_f32_demote_f64_1") (result f32)
+    f64.const -3.141593
+    call $f32_demote_f64)
+
+  (func (export "test_f32_demote_f64_2") (result f32)
+    f64.const inf
+    call $f32_demote_f64)
+
+  (func (export "test_f32_demote_f64_3") (result f32)
+    f64.const -inf
+    call $f32_demote_f64)
+
+  (func (export "test_f32_demote_f64_4") (result f32)
+    f64.const 1.7976931348623157e+308
+    call $f32_demote_f64)
+
+  (func (export "test_f32_demote_f64_5") (result f32)
+    f64.const -1.7976931348623157e+308
+    call $f32_demote_f64)
+
+  (func (export "test_f32_demote_f64_6") (result f32)
+    f64.const nan
+    call $f32_demote_f64)
+
+  (func (export "test_f32_demote_f64_7") (result f32)
+    f64.const -nan
+    call $f32_demote_f64)
+
+  (func (export "test_f32_demote_f64_8") (result f32)
+    f64.const 0
+    call $f32_demote_f64)
+
+  (func (export "test_f32_demote_f64_9") (result f32)
+    f64.const -0
+    call $f32_demote_f64)
+
+  (func $f64_promote_f32 (param f32) (result f64)
+    get_local 0
+    f64.promote/f32)
+
+  (func (export "test_f64_promote_f32_0") (result f64)
+    f32.const 3.141593
+    call $f64_promote_f32)
+
+  (func (export "test_f64_promote_f32_1") (result f64)
+    f32.const -3.141593
+    call $f64_promote_f32)
+
+  (func (export "test_f64_promote_f32_2") (result f64)
+    f32.const inf
+    call $f64_promote_f32)
+
+  (func (export "test_f64_promote_f32_3") (result f64)
+    f32.const -inf
+    call $f64_promote_f32)
+
+  (func (export "test_f64_promote_f32_4") (result f64)
+    f32.const 3.40282347e+38
+    call $f64_promote_f32)
+
+  (func (export "test_f64_promote_f32_5") (result f64)
+    f32.const -3.40282347e+38
+    call $f64_promote_f32)
+
+  (func (export "test_f64_promote_f32_6") (result f64)
+    f32.const nan
+    call $f64_promote_f32)
+
+  (func (export "test_f64_promote_f32_7") (result f64)
+    f32.const -nan
+    call $f64_promote_f32)
+
+  (func (export "test_f64_promote_f32_8") (result f64)
+    f32.const 0
+    call $f64_promote_f32)
+
+  (func (export "test_f64_promote_f32_9") (result f64)
+    f32.const -0
+    call $f64_promote_f32)
+)
+(;; STDOUT ;;;
+test_f32_demote_f64_0() => f32:3.141593
+test_f32_demote_f64_1() => f32:-3.141593
+test_f32_demote_f64_2() => f32:inf
+test_f32_demote_f64_3() => f32:-inf
+test_f32_demote_f64_4() => f32:inf
+test_f32_demote_f64_5() => f32:-inf
+test_f32_demote_f64_6() => f32:nan
+test_f32_demote_f64_7() => f32:-nan
+test_f32_demote_f64_8() => f32:0.000000
+test_f32_demote_f64_9() => f32:-0.000000
+test_f64_promote_f32_0() => f64:3.141593
+test_f64_promote_f32_1() => f64:-3.141593
+test_f64_promote_f32_2() => f64:inf
+test_f64_promote_f32_3() => f64:-inf
+test_f64_promote_f32_4() => f64:340282346638528859811704183484516925440.000000
+test_f64_promote_f32_5() => f64:-340282346638528859811704183484516925440.000000
+test_f64_promote_f32_6() => f64:nan
+test_f64_promote_f32_7() => f64:-nan
+test_f64_promote_f32_8() => f64:0.000000
+test_f64_promote_f32_9() => f64:-0.000000
+;;; STDOUT ;;)


### PR DESCRIPTION
This PR adds JIT tests for the following floating-point conversion opcodes covered by #93:

- `f32.demote/f64`
- `f64.promote/f32`