### PR TITLE
Update to the latest version of OMR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/dabeaz/ply
 [submodule "third_party/omr"]
 	path = third_party/omr
-	url = https://github.com/wasmjit-omr/omr.git
+	url = https://github.com/eclipse/omr.git

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -24,6 +24,8 @@ add_library(wabtjit STATIC
 
 # Mark JitBuilder include directories as "system" include directories. For most compilers, this
 # suppresses any warnings they would otherwise generate.
+set(JITBUILDER_EXTRA_INCLUDE ${CMAKE_SOURCE_DIR}/third_party/omr/compiler ${CMAKE_SOURCE_DIR}/third_party/omr)
 get_property(JITBUILDER_INCLUDE TARGET jitbuilder PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(wabtjit SYSTEM PUBLIC "${JITBUILDER_INCLUDE}")
+target_include_directories(wabtjit SYSTEM PUBLIC "${JITBUILDER_EXTRA_INCLUDE}")
 target_link_libraries(wabtjit PUBLIC jitbuilder)

--- a/src/jit/environment.cc
+++ b/src/jit/environment.cc
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+#include <cstddef>
+
 #include "environment.h"
-#include "Jit.hpp"
+#include "JitBuilder.hpp"
 
 namespace wabt {
 namespace jit {

--- a/src/jit/type-dictionary.cc
+++ b/src/jit/type-dictionary.cc
@@ -20,9 +20,9 @@
 wabt::jit::TypeDictionary::TypeDictionary() : TR::TypeDictionary() {
     using namespace wabt::interp;
     DefineUnion("Value");
-    UnionField("Value", "i32", toIlType<decltype(Value::i32)>());
-    UnionField("Value", "i64", toIlType<decltype(Value::i64)>());
-    UnionField("Value", "f32", toIlType<float>());
-    UnionField("Value", "f64", toIlType<double>());
+    UnionField("Value", "i32", toIlType<decltype(Value::i32)>(this));
+    UnionField("Value", "i64", toIlType<decltype(Value::i64)>(this));
+    UnionField("Value", "f32", toIlType<float>(this));
+    UnionField("Value", "f64", toIlType<double>(this));
     CloseUnion("Value");
 }

--- a/src/jit/wabtjit.cc
+++ b/src/jit/wabtjit.cc
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+#include <cstddef>
+
 #include "wabtjit.h"
 #include "type-dictionary.h"
 #include "function-builder.h"
 
-#include "Jit.hpp"
+extern int32_t internal_compileMethodBuilder(TR::MethodBuilder * methodBuilder, void ** entryPoint);
 
 namespace wabt {
 namespace jit {
@@ -26,9 +28,9 @@ namespace jit {
 JITedFunction compile(interp::Thread* thread, interp::DefinedFunc* fn) {
   TypeDictionary types;
   FunctionBuilder builder(thread, fn, &types);
-  uint8_t* function = nullptr;
+  void* function = nullptr;
 
-  if (compileMethodBuilder(&builder, &function) == 0) {
+  if (internal_compileMethodBuilder(&builder, &function) == 0) {
     return reinterpret_cast<JITedFunction>(function);
   } else {
     return nullptr;

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -37,8 +37,6 @@
 #include "src/wast-lexer.h"
 #include "src/wast-parser.h"
 
-#include "Jit.hpp"
-
 using namespace wabt;
 using namespace wabt::interp;
 


### PR DESCRIPTION
For various reasons, it makes sense for us to update to the latest
version of OMR for the JIT. Unfortunately, newer versions of OMR have a
different API for JitBuilder that doesn't include some of the
functionality that we need. For now, we're using a hacky workaround to
use the internal definitions of the JitBuilder classes rather than the
externally visible class definitions to allow access to those missing
functions.

The intention right now is for wasmjit-omr to eventually be updated to
use the JitBuilder API in its intended way once these problems are
corrected. However, it's easier for this to be done after updating OMR
rather than doing it at the same time.