### PR TITLE
Fix bad stack trace on call_indirect failure

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -96,6 +96,9 @@ FunctionBuilder::Result_t FunctionBuilder::CallHelper(wabt::interp::Thread* th, 
 FunctionBuilder::Result_t FunctionBuilder::CallIndirectHelper(wabt::interp::Thread* th, Index table_index, Index sig_index, Index entry_index, uint8_t* current_pc) {
   using namespace wabt::interp;
   auto* env = th->env_;
+
+  th->set_pc(current_pc - th->GetIstream());
+
   Table* table = &env->tables_[table_index];
   TRAP_IF(entry_index >= table->func_indexes.size(), UndefinedTableIndex);
   Index func_index = table->func_indexes[entry_index];


### PR DESCRIPTION
When encountering a call_indirect opcode in JITted code, certain
failures (e.g. function signature mismatch) would result in a stack
trace with an incorrect topmost frame. This was caused by the PC being
stale due to not being updated in CallIndirectHelper before trapping.
The PC should now be updated correctly in such cases and thus the stack
trace should now be correct.

Fixes #132