### PR TITLE
Add JIT tests for integer sign extension opcodes

### DIFF
--- a/test/jit/sign_ext.txt
+++ b/test/jit/sign_ext.txt
@@ -1,0 +1,150 @@
+;;; TOOL: run-interp-jit
+;;; ARGS*: --enable-sign-extension
+(module
+  (func $i32_extend8_s (param i32) (result i32)
+    get_local 0
+    i32.extend8_s)
+
+  (func (export "test_i32_extend8_s_0") (result i32)
+    i32.const 0
+    call $i32_extend8_s)
+
+  (func (export "test_i32_extend8_s_1") (result i32)
+    i32.const 0x7f
+    call $i32_extend8_s)
+
+  (func (export "test_i32_extend8_s_2") (result i32)
+    i32.const 0x80
+    call $i32_extend8_s)
+
+  (func (export "test_i32_extend8_s_3") (result i32)
+    i32.const 0xffffff00
+    call $i32_extend8_s)
+
+  (func (export "test_i32_extend8_s_4") (result i32)
+    i32.const 0xffffffff
+    call $i32_extend8_s)
+
+  (func $i32_extend16_s (param i32) (result i32)
+    get_local 0
+    i32.extend16_s)
+
+  (func (export "test_i32_extend16_s_0") (result i32)
+    i32.const 0
+    call $i32_extend16_s)
+
+  (func (export "test_i32_extend16_s_1") (result i32)
+    i32.const 0x7fff
+    call $i32_extend16_s)
+
+  (func (export "test_i32_extend16_s_2") (result i32)
+    i32.const 0x8000
+    call $i32_extend16_s)
+
+  (func (export "test_i32_extend16_s_3") (result i32)
+    i32.const 0xffff0000
+    call $i32_extend16_s)
+
+  (func (export "test_i32_extend16_s_4") (result i32)
+    i32.const 0xffffffff
+    call $i32_extend16_s)
+
+  (func $i64_extend8_s (param i64) (result i64)
+    get_local 0
+    i64.extend8_s)
+
+  (func (export "test_i64_extend8_s_0") (result i64)
+    i64.const 0
+    call $i64_extend8_s)
+
+  (func (export "test_i64_extend8_s_1") (result i64)
+    i64.const 0x7f
+    call $i64_extend8_s)
+
+  (func (export "test_i64_extend8_s_2") (result i64)
+    i64.const 0x80
+    call $i64_extend8_s)
+
+  (func (export "test_i64_extend8_s_3") (result i64)
+    i64.const 0xffffffffffffff00
+    call $i64_extend8_s)
+
+  (func (export "test_i64_extend8_s_4") (result i64)
+    i64.const 0xffffffffffffffff
+    call $i64_extend8_s)
+
+  (func $i64_extend16_s (param i64) (result i64)
+    get_local 0
+    i64.extend16_s)
+
+  (func (export "test_i64_extend16_s_0") (result i64)
+    i64.const 0
+    call $i64_extend16_s)
+
+  (func (export "test_i64_extend16_s_1") (result i64)
+    i64.const 0x7fff
+    call $i64_extend16_s)
+
+  (func (export "test_i64_extend16_s_2") (result i64)
+    i64.const 0x8000
+    call $i64_extend16_s)
+
+  (func (export "test_i64_extend16_s_3") (result i64)
+    i64.const 0xffffffffffff0000
+    call $i64_extend16_s)
+
+  (func (export "test_i64_extend16_s_4") (result i64)
+    i64.const 0xffffffffffffffff
+    call $i64_extend16_s)
+
+  (func $i64_extend32_s (param i64) (result i64)
+    get_local 0
+    i64.extend32_s)
+
+  (func (export "test_i64_extend32_s_0") (result i64)
+    i64.const 0
+    call $i64_extend32_s)
+
+  (func (export "test_i64_extend32_s_1") (result i64)
+    i64.const 0x7fffffff
+    call $i64_extend32_s)
+
+  (func (export "test_i64_extend32_s_2") (result i64)
+    i64.const 0x80000000
+    call $i64_extend32_s)
+
+  (func (export "test_i64_extend32_s_3") (result i64)
+    i64.const 0xffffffff00000000
+    call $i64_extend32_s)
+
+  (func (export "test_i64_extend32_s_4") (result i64)
+    i64.const 0xffffffffffffffff
+    call $i64_extend32_s)
+)
+(;; STDOUT ;;;
+test_i32_extend8_s_0() => i32:0
+test_i32_extend8_s_1() => i32:127
+test_i32_extend8_s_2() => i32:4294967168
+test_i32_extend8_s_3() => i32:0
+test_i32_extend8_s_4() => i32:4294967295
+test_i32_extend16_s_0() => i32:0
+test_i32_extend16_s_1() => i32:32767
+test_i32_extend16_s_2() => i32:4294934528
+test_i32_extend16_s_3() => i32:0
+test_i32_extend16_s_4() => i32:4294967295
+test_i64_extend8_s_0() => i64:0
+test_i64_extend8_s_1() => i64:127
+test_i64_extend8_s_2() => i64:18446744073709551488
+test_i64_extend8_s_3() => i64:0
+test_i64_extend8_s_4() => i64:18446744073709551615
+test_i64_extend16_s_0() => i64:0
+test_i64_extend16_s_1() => i64:32767
+test_i64_extend16_s_2() => i64:18446744073709518848
+test_i64_extend16_s_3() => i64:0
+test_i64_extend16_s_4() => i64:18446744073709551615
+test_i64_extend32_s_0() => i64:0
+test_i64_extend32_s_1() => i64:2147483647
+test_i64_extend32_s_2() => i64:18446744071562067968
+test_i64_extend32_s_3() => i64:0
+test_i64_extend32_s_4() => i64:18446744073709551615
+;;; STDOUT ;;)


### PR DESCRIPTION
This PR adds JIT tests for the following opcodes covered under #94:

- `i32.extend8_s`
- `i32.extend16_s`
- `i64.extend8_s`
- `i64.extend16_s`
- `i64.extend32_s`