### PR TITLE
Optimize several float operations using bitwise instructions

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -1301,20 +1301,10 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 
     case Opcode::F32Abs:
       EmitUnaryOp<float>(b, pc, &stack, [&](TR::IlValue* value) {
-        auto* return_value = b->Copy(value);
-
-        TR::IlBuilder* zero_path = nullptr;
-        TR::IlBuilder* nonzero_path = nullptr;
-        TR::IlBuilder* neg_path = nullptr;
-
-        // We have to check explicitly for 0.0, since abs(-0.0) is 0.0.
-        b->IfThenElse(&zero_path, &nonzero_path, b->EqualTo(value, b->ConstFloat(0)));
-        zero_path->StoreOver(return_value, zero_path->ConstFloat(0));
-
-        nonzero_path->IfThen(&neg_path, nonzero_path->LessThan(value, nonzero_path->ConstFloat(0)));
-        neg_path->StoreOver(return_value, neg_path->Mul(value, neg_path->ConstFloat(-1)));
-
-        return return_value;
+        return b->ConvertBitsTo(Float,
+        b->                     And(
+        b->                         ConvertBitsTo(Int32, value),
+        b->                         ConstInt32(0x7fffffff)));
       });
       break;
 
@@ -1405,20 +1395,10 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 
     case Opcode::F64Abs:
       EmitUnaryOp<double>(b, pc, &stack, [&](TR::IlValue* value) {
-        auto* return_value = b->Copy(value);
-
-        TR::IlBuilder* zero_path = nullptr;
-        TR::IlBuilder* nonzero_path = nullptr;
-        TR::IlBuilder* neg_path = nullptr;
-
-        // We have to check explicitly for 0.0, since abs(-0.0) is 0.0.
-        b->IfThenElse(&zero_path, &nonzero_path, b->EqualTo(value, b->ConstDouble(0)));
-        zero_path->StoreOver(return_value, zero_path->ConstDouble(0));
-
-        nonzero_path->IfThen(&neg_path, nonzero_path->LessThan(value, nonzero_path->ConstDouble(0)));
-        neg_path->StoreOver(return_value, neg_path->Mul(value, neg_path->ConstDouble(-1)));
-
-        return return_value;
+        return b->ConvertBitsTo(Double,
+        b->                     And(
+        b->                         ConvertBitsTo(Int64, value),
+        b->                         ConstInt64(0x7fffffffffffffffL)));
       });
       break;
 

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -146,22 +146,10 @@ FunctionBuilder::FunctionBuilder(interp::Thread* thread, interp::DefinedFunc* fn
                  Float,
                  1,
                  Float);
-  DefineFunction("f32_copysign", __FILE__, "0",
-                 reinterpret_cast<void*>(static_cast<float (*)(float, float)>(std::copysign)),
-                 Float,
-                 2,
-                 Float,
-                 Float);
   DefineFunction("f64_sqrt", __FILE__, "0",
                  reinterpret_cast<void*>(static_cast<double (*)(double)>(std::sqrt)),
                  Double,
                  1,
-                 Double);
-  DefineFunction("f64_copysign", __FILE__, "0",
-                 reinterpret_cast<void*>(static_cast<double (*)(double, double)>(std::copysign)),
-                 Double,
-                 2,
-                 Double,
                  Double);
   DefineFunction("CallHelper", __FILE__, "0",
                  reinterpret_cast<void*>(CallHelper),
@@ -1368,7 +1356,14 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 
     case Opcode::F32Copysign:
       EmitBinaryOp<float>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
-        return b->Call("f32_copysign", 2, lhs, rhs);
+        return b->ConvertBitsTo(Float,
+        b->                     Or(
+        b->                        And(
+        b->                            ConvertBitsTo(Int32, lhs),
+        b->                            ConstInt32(0x7fffffff)),
+        b->                        And(
+        b->                            ConvertBitsTo(Int32, rhs),
+        b->                            ConstInt32(0x80000000))));
       });
       break;
 
@@ -1465,7 +1460,14 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 
     case Opcode::F64Copysign:
       EmitBinaryOp<double>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
-        return b->Call("f64_copysign", 2, lhs, rhs);
+        return b->ConvertBitsTo(Double,
+        b->                     Or(
+        b->                        And(
+        b->                            ConvertBitsTo(Int64, lhs),
+        b->                            ConstInt64(0x7fffffffffffffffL)),
+        b->                        And(
+        b->                            ConvertBitsTo(Int64, rhs),
+        b->                            ConstInt64(0x8000000000000000L))));
       });
       break;
 


### PR DESCRIPTION
Several floating-point instructions were implemented poorly in the JIT due to not having any native JitBuilder services to perform their tasks. Specifically, the `f32.copysign` and `f64.copysign` instructions were using helper calls to `std::copysign` and the `f32.abs` and `f64.abs` instructions were performing several comparisons and branches. All four of these instructions can be done more efficiently by making use of bitwise operations on the floating-point values to deal with the sign bit.