### PR TITLE
Implement floating-point min/max

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -1411,6 +1411,68 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
       });
       break;
 
+    case Opcode::F32Min:
+      EmitBinaryOp<float>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        auto* result = b->ConstFloat(0.0f);
+
+        TR::IlBuilder* eq_path = nullptr;
+        TR::IlBuilder* ne_path = nullptr;
+        TR::IlBuilder* lt_path = nullptr;
+        TR::IlBuilder* gt_path = nullptr;
+
+        b->IfThenElse(&eq_path, &ne_path, b->EqualTo(lhs, rhs));
+
+        // Using bitwise OR here ensures that min(-0.0, 0.0) = -0.0
+        eq_path->StoreOver(result,
+        eq_path->          ConvertBitsTo(Float,
+        eq_path->                        Or(
+        eq_path->                           ConvertBitsTo(Int32, lhs),
+        eq_path->                           ConvertBitsTo(Int32, rhs))));
+
+        // We need to explicitly check if lhs is nan, since we must return lhs in that case
+        ne_path->IfThenElse(&lt_path,
+                            &gt_path,
+        ne_path->           Or(
+        ne_path->              NotEqualTo(lhs, lhs),
+        ne_path->              LessThan(lhs, rhs)));
+        lt_path->StoreOver(result, lhs);
+        gt_path->StoreOver(result, rhs);
+
+        return result;
+      });
+      break;
+
+    case Opcode::F32Max:
+      EmitBinaryOp<float>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        auto* result = b->ConstFloat(0.0f);
+
+        TR::IlBuilder* eq_path = nullptr;
+        TR::IlBuilder* ne_path = nullptr;
+        TR::IlBuilder* lt_path = nullptr;
+        TR::IlBuilder* gt_path = nullptr;
+
+        b->IfThenElse(&eq_path, &ne_path, b->EqualTo(lhs, rhs));
+
+        // Using bitwise AND here ensures that max(-0.0, 0.0) = 0.0
+        eq_path->StoreOver(result,
+        eq_path->          ConvertBitsTo(Float,
+        eq_path->                        And(
+        eq_path->                            ConvertBitsTo(Int32, lhs),
+        eq_path->                            ConvertBitsTo(Int32, rhs))));
+
+        // We need to explicitly check if rhs is nan, since we must return rhs in that case
+        ne_path->IfThenElse(&lt_path,
+                            &gt_path,
+        ne_path->           Or(
+        ne_path->              NotEqualTo(rhs, rhs),
+        ne_path->              LessThan(lhs, rhs)));
+        lt_path->StoreOver(result, rhs);
+        gt_path->StoreOver(result, lhs);
+
+        return result;
+      });
+      break;
+
     case Opcode::F64Abs:
       EmitUnaryOp<double>(b, pc, &stack, [&](TR::IlValue* value) {
         auto* return_value = b->Copy(value);
@@ -1505,6 +1567,68 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
     case Opcode::F64Ge:
       EmitBinaryOp<double, int>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
         return b->GreaterOrEqualTo(lhs, rhs);
+      });
+      break;
+
+    case Opcode::F64Min:
+      EmitBinaryOp<double>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        auto* result = b->ConstDouble(0.0f);
+
+        TR::IlBuilder* eq_path = nullptr;
+        TR::IlBuilder* ne_path = nullptr;
+        TR::IlBuilder* lt_path = nullptr;
+        TR::IlBuilder* gt_path = nullptr;
+
+        b->IfThenElse(&eq_path, &ne_path, b->EqualTo(lhs, rhs));
+
+        // Using bitwise OR here ensures that min(-0.0, 0.0) = -0.0
+        eq_path->StoreOver(result,
+        eq_path->          ConvertBitsTo(Double,
+        eq_path->                        Or(
+        eq_path->                           ConvertBitsTo(Int64, lhs),
+        eq_path->                           ConvertBitsTo(Int64, rhs))));
+
+        // We need to explicitly check if lhs is nan, since we must return lhs in that case
+        ne_path->IfThenElse(&lt_path,
+                            &gt_path,
+        ne_path->           Or(
+        ne_path->              NotEqualTo(lhs, lhs),
+        ne_path->              LessThan(lhs, rhs)));
+        lt_path->StoreOver(result, lhs);
+        gt_path->StoreOver(result, rhs);
+
+        return result;
+      });
+      break;
+
+    case Opcode::F64Max:
+      EmitBinaryOp<double>(b, pc, &stack, [&](TR::IlValue* lhs, TR::IlValue* rhs) {
+        auto* result = b->ConstDouble(0.0);
+
+        TR::IlBuilder* eq_path = nullptr;
+        TR::IlBuilder* ne_path = nullptr;
+        TR::IlBuilder* lt_path = nullptr;
+        TR::IlBuilder* gt_path = nullptr;
+
+        b->IfThenElse(&eq_path, &ne_path, b->EqualTo(lhs, rhs));
+
+        // Using bitwise AND here ensures that max(-0.0, 0.0) = 0.0
+        eq_path->StoreOver(result,
+        eq_path->          ConvertBitsTo(Double,
+        eq_path->                        And(
+        eq_path->                            ConvertBitsTo(Int64, lhs),
+        eq_path->                            ConvertBitsTo(Int64, rhs))));
+
+        // We need to explicitly check if rhs is nan, since we must return rhs in that case
+        ne_path->IfThenElse(&lt_path,
+                            &gt_path,
+        ne_path->           Or(
+        ne_path->              NotEqualTo(rhs, rhs),
+        ne_path->              LessThan(lhs, rhs)));
+        lt_path->StoreOver(result, rhs);
+        gt_path->StoreOver(result, lhs);
+
+        return result;
       });
       break;
 

--- a/test/jit/f32_min_max.txt
+++ b/test/jit/f32_min_max.txt
@@ -1,0 +1,196 @@
+;;; TOOL: run-interp-jit
+(module
+  (func $f32_min (param f32) (param f32) (result f32)
+    get_local 0
+    get_local 1
+    f32.min)
+
+  (func (export "test_f32_min_0") (result f32)
+    f32.const -1.0
+    f32.const 1.0
+    call $f32_min)
+
+  (func (export "test_f32_min_1") (result f32)
+    f32.const 0.0
+    f32.const 1.0
+    call $f32_min)
+
+  (func (export "test_f32_min_2") (result f32)
+    f32.const -0.0
+    f32.const -1.0
+    call $f32_min)
+
+  (func (export "test_f32_min_3") (result f32)
+    f32.const -inf
+    f32.const 1.0
+    call $f32_min)
+
+  (func (export "test_f32_min_4") (result f32)
+    f32.const -1.0
+    f32.const -inf
+    call $f32_min)
+
+  (func (export "test_f32_min_5") (result f32)
+    f32.const inf
+    f32.const 3.14
+    call $f32_min)
+
+  (func (export "test_f32_min_6") (result f32)
+    f32.const -6.28
+    f32.const inf
+    call $f32_min)
+
+  (func (export "test_f32_min_7") (result f32)
+    f32.const -0.0
+    f32.const 0.0
+    call $f32_min)
+
+  (func (export "test_f32_min_8") (result f32)
+    f32.const 0.0
+    f32.const -0.0
+    call $f32_min)
+
+  (func (export "test_f32_min_9") (result f32)
+    f32.const 0.0
+    f32.const 0.0
+    call $f32_min)
+
+  (func (export "test_f32_min_10") (result f32)
+    f32.const -inf
+    f32.const nan
+    call $f32_min)
+
+  (func (export "test_f32_min_11") (result f32)
+    f32.const -nan
+    f32.const -inf
+    call $f32_min)
+
+  (func (export "test_f32_min_12") (result f32)
+    f32.const nan
+    f32.const -nan
+    call $f32_min
+    f32.abs) ;; Sign of nan doesn't matter here
+
+  (func (export "test_f32_min_13") (result f32)
+    f32.const nan
+    f32.const nan
+    call $f32_min)
+
+  (func (export "test_f32_min_14") (result f32)
+    f32.const -nan
+    f32.const -nan
+    call $f32_min)
+
+  (func $f32_max (param f32) (param f32) (result f32)
+    get_local 0
+    get_local 1
+    f32.max)
+
+  (func (export "test_f32_max_0") (result f32)
+    f32.const -1.0
+    f32.const 1.0
+    call $f32_max)
+
+  (func (export "test_f32_max_1") (result f32)
+    f32.const -0.0
+    f32.const -1.0
+    call $f32_max)
+
+  (func (export "test_f32_max_2") (result f32)
+    f32.const 0.0
+    f32.const 1.0
+    call $f32_max)
+
+  (func (export "test_f32_max_3") (result f32)
+    f32.const inf
+    f32.const -1.0
+    call $f32_max)
+
+  (func (export "test_f32_max_4") (result f32)
+    f32.const 1.0
+    f32.const inf
+    call $f32_max)
+
+  (func (export "test_f32_max_5") (result f32)
+    f32.const -inf
+    f32.const 3.14
+    call $f32_max)
+
+  (func (export "test_f32_max_6") (result f32)
+    f32.const -6.28
+    f32.const -inf
+    call $f32_max)
+
+  (func (export "test_f32_max_7") (result f32)
+    f32.const -0.0
+    f32.const 0.0
+    call $f32_max)
+
+  (func (export "test_f32_max_8") (result f32)
+    f32.const 0.0
+    f32.const -0.0
+    call $f32_max)
+
+  (func (export "test_f32_max_9") (result f32)
+    f32.const -0.0
+    f32.const -0.0
+    call $f32_max)
+
+  (func (export "test_f32_max_10") (result f32)
+    f32.const inf
+    f32.const nan
+    call $f32_max)
+
+  (func (export "test_f32_max_11") (result f32)
+    f32.const -nan
+    f32.const inf
+    call $f32_max)
+
+  (func (export "test_f32_max_12") (result f32)
+    f32.const nan
+    f32.const -nan
+    call $f32_max
+    f32.abs) ;; Sign of nan doesn't matter here
+
+  (func (export "test_f32_max_13") (result f32)
+    f32.const nan
+    f32.const nan
+    call $f32_max)
+
+  (func (export "test_f32_max_14") (result f32)
+    f32.const -nan
+    f32.const -nan
+    call $f32_max)
+)
+(;; STDOUT ;;;
+test_f32_min_0() => f32:-1.000000
+test_f32_min_1() => f32:0.000000
+test_f32_min_2() => f32:-1.000000
+test_f32_min_3() => f32:-inf
+test_f32_min_4() => f32:-inf
+test_f32_min_5() => f32:3.140000
+test_f32_min_6() => f32:-6.280000
+test_f32_min_7() => f32:-0.000000
+test_f32_min_8() => f32:-0.000000
+test_f32_min_9() => f32:0.000000
+test_f32_min_10() => f32:nan
+test_f32_min_11() => f32:-nan
+test_f32_min_12() => f32:nan
+test_f32_min_13() => f32:nan
+test_f32_min_14() => f32:-nan
+test_f32_max_0() => f32:1.000000
+test_f32_max_1() => f32:-0.000000
+test_f32_max_2() => f32:1.000000
+test_f32_max_3() => f32:inf
+test_f32_max_4() => f32:inf
+test_f32_max_5() => f32:3.140000
+test_f32_max_6() => f32:-6.280000
+test_f32_max_7() => f32:0.000000
+test_f32_max_8() => f32:0.000000
+test_f32_max_9() => f32:-0.000000
+test_f32_max_10() => f32:nan
+test_f32_max_11() => f32:-nan
+test_f32_max_12() => f32:nan
+test_f32_max_13() => f32:nan
+test_f32_max_14() => f32:-nan
+;;; STDOUT ;;)

--- a/test/jit/f64_min_max.txt
+++ b/test/jit/f64_min_max.txt
@@ -1,0 +1,196 @@
+;;; TOOL: run-interp-jit
+(module
+  (func $f64_min (param f64) (param f64) (result f64)
+    get_local 0
+    get_local 1
+    f64.min)
+
+  (func (export "test_f64_min_0") (result f64)
+    f64.const -1.0
+    f64.const 1.0
+    call $f64_min)
+
+  (func (export "test_f64_min_1") (result f64)
+    f64.const 0.0
+    f64.const 1.0
+    call $f64_min)
+
+  (func (export "test_f64_min_2") (result f64)
+    f64.const -0.0
+    f64.const -1.0
+    call $f64_min)
+
+  (func (export "test_f64_min_3") (result f64)
+    f64.const -inf
+    f64.const 1.0
+    call $f64_min)
+
+  (func (export "test_f64_min_4") (result f64)
+    f64.const -1.0
+    f64.const -inf
+    call $f64_min)
+
+  (func (export "test_f64_min_5") (result f64)
+    f64.const inf
+    f64.const 3.14
+    call $f64_min)
+
+  (func (export "test_f64_min_6") (result f64)
+    f64.const -6.28
+    f64.const inf
+    call $f64_min)
+
+  (func (export "test_f64_min_7") (result f64)
+    f64.const -0.0
+    f64.const 0.0
+    call $f64_min)
+
+  (func (export "test_f64_min_8") (result f64)
+    f64.const 0.0
+    f64.const -0.0
+    call $f64_min)
+
+  (func (export "test_f64_min_9") (result f64)
+    f64.const 0.0
+    f64.const 0.0
+    call $f64_min)
+
+  (func (export "test_f64_min_10") (result f64)
+    f64.const -inf
+    f64.const nan
+    call $f64_min)
+
+  (func (export "test_f64_min_11") (result f64)
+    f64.const -nan
+    f64.const -inf
+    call $f64_min)
+
+  (func (export "test_f64_min_12") (result f64)
+    f64.const nan
+    f64.const -nan
+    call $f64_min
+    f64.abs) ;; Sign of nan doesn't matter here
+
+  (func (export "test_f64_min_13") (result f64)
+    f64.const nan
+    f64.const nan
+    call $f64_min)
+
+  (func (export "test_f64_min_14") (result f64)
+    f64.const -nan
+    f64.const -nan
+    call $f64_min)
+
+  (func $f64_max (param f64) (param f64) (result f64)
+    get_local 0
+    get_local 1
+    f64.max)
+
+  (func (export "test_f64_max_0") (result f64)
+    f64.const -1.0
+    f64.const 1.0
+    call $f64_max)
+
+  (func (export "test_f64_max_1") (result f64)
+    f64.const -0.0
+    f64.const -1.0
+    call $f64_max)
+
+  (func (export "test_f64_max_2") (result f64)
+    f64.const 0.0
+    f64.const 1.0
+    call $f64_max)
+
+  (func (export "test_f64_max_3") (result f64)
+    f64.const inf
+    f64.const -1.0
+    call $f64_max)
+
+  (func (export "test_f64_max_4") (result f64)
+    f64.const 1.0
+    f64.const inf
+    call $f64_max)
+
+  (func (export "test_f64_max_5") (result f64)
+    f64.const -inf
+    f64.const 3.14
+    call $f64_max)
+
+  (func (export "test_f64_max_6") (result f64)
+    f64.const -6.28
+    f64.const -inf
+    call $f64_max)
+
+  (func (export "test_f64_max_7") (result f64)
+    f64.const -0.0
+    f64.const 0.0
+    call $f64_max)
+
+  (func (export "test_f64_max_8") (result f64)
+    f64.const 0.0
+    f64.const -0.0
+    call $f64_max)
+
+  (func (export "test_f64_max_9") (result f64)
+    f64.const -0.0
+    f64.const -0.0
+    call $f64_max)
+
+  (func (export "test_f64_max_10") (result f64)
+    f64.const inf
+    f64.const nan
+    call $f64_max)
+
+  (func (export "test_f64_max_11") (result f64)
+    f64.const -nan
+    f64.const inf
+    call $f64_max)
+
+  (func (export "test_f64_max_12") (result f64)
+    f64.const nan
+    f64.const -nan
+    call $f64_max
+    f64.abs) ;; Sign of nan doesn't matter here
+
+  (func (export "test_f64_max_13") (result f64)
+    f64.const nan
+    f64.const nan
+    call $f64_max)
+
+  (func (export "test_f64_max_14") (result f64)
+    f64.const -nan
+    f64.const -nan
+    call $f64_max)
+)
+(;; STDOUT ;;;
+test_f64_min_0() => f64:-1.000000
+test_f64_min_1() => f64:0.000000
+test_f64_min_2() => f64:-1.000000
+test_f64_min_3() => f64:-inf
+test_f64_min_4() => f64:-inf
+test_f64_min_5() => f64:3.140000
+test_f64_min_6() => f64:-6.280000
+test_f64_min_7() => f64:-0.000000
+test_f64_min_8() => f64:-0.000000
+test_f64_min_9() => f64:0.000000
+test_f64_min_10() => f64:nan
+test_f64_min_11() => f64:-nan
+test_f64_min_12() => f64:nan
+test_f64_min_13() => f64:nan
+test_f64_min_14() => f64:-nan
+test_f64_max_0() => f64:1.000000
+test_f64_max_1() => f64:-0.000000
+test_f64_max_2() => f64:1.000000
+test_f64_max_3() => f64:inf
+test_f64_max_4() => f64:inf
+test_f64_max_5() => f64:3.140000
+test_f64_max_6() => f64:-6.280000
+test_f64_max_7() => f64:0.000000
+test_f64_max_8() => f64:0.000000
+test_f64_max_9() => f64:-0.000000
+test_f64_max_10() => f64:nan
+test_f64_max_11() => f64:-nan
+test_f64_max_12() => f64:nan
+test_f64_max_13() => f64:nan
+test_f64_max_14() => f64:-nan
+;;; STDOUT ;;)


### PR DESCRIPTION
This PR implements the following opcodes in the JIT covered by #51:

- `f32.min`
- `f32.max`
- `f64.min`
- `f64.max`

Note that the tests in this PR will fail until #131 is merged, as the floating-point min and max opcodes run into the same issue where `NaN != NaN` is evaluating as false which is causing subtly wrong behaviour. Until such a time as that change is merged, this PR will be marked WIP and it shouldn't be merged until the tests are passing.