### PR TITLE
Implement saturating float to int conversions

### DIFF
--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -568,6 +568,8 @@ TR::IlValue* FunctionBuilder::EmitIsNan<double>(TR::IlBuilder* b, TR::IlValue* v
 template <typename ToType, typename FromType>
 void FunctionBuilder::EmitTruncation(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack) {
   static_assert(std::is_floating_point<FromType>::value, "FromType in EmitTruncation call must be a floating point type");
+  static_assert(std::is_integral<ToType>::value, "ToType in EmitTruncation call must be an integer type");
+  static_assert(std::is_signed<ToType>::value, "ToType in EmitTruncation call must be signed");
 
   auto* value = stack->Pop();
 
@@ -607,7 +609,7 @@ void FunctionBuilder::EmitTruncation(TR::IlBuilder* b, const uint8_t* pc, Virtua
  */
 template <typename ToType, typename FromType>
 void FunctionBuilder::EmitUnsignedTruncation(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack) {
-  static_assert(std::is_floating_point<FromType>::value, "FromType in EmitTruncation call must be a floating point type");
+  static_assert(std::is_floating_point<FromType>::value, "FromType in EmitUnsignedTruncation call must be a floating point type");
   static_assert(std::is_integral<ToType>::value, "ToType in EmitUnsignedTruncation call must be an integer type");
   static_assert(std::is_unsigned<ToType>::value, "ToType in EmitUnsignedTruncation call must be unsigned");
 
@@ -633,6 +635,85 @@ void FunctionBuilder::EmitUnsignedTruncation(TR::IlBuilder* b, const uint8_t* pc
   auto* new_value = b->UnsignedConvertTo(target_type, b->ConvertTo(Int64, value));
 
   stack->Push(new_value);
+}
+
+template <typename ToType, typename FromType>
+void FunctionBuilder::EmitSaturatingTruncation(TR::IlBuilder* b, VirtualStack* stack) {
+  static_assert(std::is_floating_point<FromType>::value, "FromType in EmitTruncation call must be a floating point type");
+  static_assert(std::is_integral<ToType>::value, "ToType in EmitTruncation call must be an integer type");
+  static_assert(std::is_signed<ToType>::value, "ToType in EmitTruncation call must be signed");
+
+  auto* value = stack->Pop();
+  auto* result = b->Const(static_cast<ToType>(0));
+
+  TR::IlBuilder* non_nan_path = nullptr;
+
+  b->IfThen(&non_nan_path, b->EqualTo(EmitIsNan<FromType>(b, value), b->ConstInt32(0)));
+
+  TR::IlBuilder* too_high_path = nullptr;
+  TR::IlBuilder* not_too_high_path = nullptr;
+
+  non_nan_path->IfThenElse(&too_high_path, &not_too_high_path,
+  non_nan_path->           GreaterThan(value,
+  non_nan_path->                       Const(static_cast<FromType>(std::numeric_limits<ToType>::max()))));
+  too_high_path->StoreOver(result, too_high_path->Const(std::numeric_limits<ToType>::max()));
+
+  TR::IlBuilder* too_low_path = nullptr;
+  TR::IlBuilder* not_too_low_path = nullptr;
+
+  not_too_high_path->IfThenElse(&too_low_path, &not_too_low_path,
+  not_too_high_path->           LessThan(value,
+  not_too_high_path->                    Const(static_cast<FromType>(std::numeric_limits<ToType>::lowest()))));
+  too_low_path->StoreOver(result, too_low_path->Const(std::numeric_limits<ToType>::lowest()));
+
+  auto* target_type = toIlType<ToType>(b->typeDictionary());
+
+  // this could be optimized using templates or constant expressions,
+  // but the compiler should be able to simplify this anyways
+  auto* new_value = std::is_unsigned<ToType>::value ? not_too_low_path->UnsignedConvertTo(target_type, value)
+                                                    : not_too_low_path->ConvertTo(target_type, value);
+  not_too_low_path->StoreOver(result, new_value);
+
+  stack->Push(result);
+}
+
+template <typename ToType, typename FromType>
+void FunctionBuilder::EmitUnsignedSaturatingTruncation(TR::IlBuilder* b, VirtualStack* stack) {
+  static_assert(std::is_floating_point<FromType>::value, "FromType in EmitTruncation call must be a floating point type");
+  static_assert(std::is_integral<ToType>::value, "ToType in EmitUnsignedTruncation call must be an integer type");
+  static_assert(std::is_unsigned<ToType>::value, "ToType in EmitUnsignedTruncation call must be unsigned");
+
+  using ToTypeSigned = typename std::make_signed<ToType>::type;
+
+  auto* value = stack->Pop();
+  auto* result = b->Const(static_cast<ToTypeSigned>(0));
+
+  TR::IlBuilder* non_nan_path = nullptr;
+
+  b->IfThen(&non_nan_path, b->EqualTo(EmitIsNan<FromType>(b, value), b->ConstInt32(0)));
+
+  TR::IlBuilder* too_high_path = nullptr;
+  TR::IlBuilder* not_too_high_path = nullptr;
+
+  non_nan_path->IfThenElse(&too_high_path, &not_too_high_path,
+  non_nan_path->           GreaterThan(value,
+  non_nan_path->                       Const(static_cast<FromType>(std::numeric_limits<ToType>::max()))));
+  too_high_path->StoreOver(result, too_high_path->Const(static_cast<ToTypeSigned>(std::numeric_limits<ToType>::max())));
+
+  TR::IlBuilder* too_low_path = nullptr;
+  TR::IlBuilder* not_too_low_path = nullptr;
+
+  not_too_high_path->IfThenElse(&too_low_path, &not_too_low_path,
+  not_too_high_path->           LessThan(value,
+  not_too_high_path->                    Const(static_cast<FromType>(std::numeric_limits<ToType>::lowest()))));
+  too_low_path->StoreOver(result, too_low_path->Const(static_cast<ToTypeSigned>(std::numeric_limits<ToType>::lowest())));
+
+  auto* target_type = toIlType<ToType>(b->typeDictionary());
+
+  auto* new_value = not_too_low_path->UnsignedConvertTo(target_type, not_too_low_path->ConvertTo(Int64, value));
+  not_too_low_path->StoreOver(result, new_value);
+
+  stack->Push(result);
 }
 
 template <typename T>
@@ -1762,6 +1843,41 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 //    UNSIGNED TYPE NOT HANDLED
 //    case Opcode::I64TruncF64U:
 //      EmitTruncation<uint64_t, double>(b, pc, &stack);
+//      break;
+
+    case Opcode::I32TruncSatF32S:
+      EmitSaturatingTruncation<int32_t, float>(b, &stack);
+      break;
+
+    case Opcode::I32TruncSatF32U:
+      EmitUnsignedSaturatingTruncation<uint32_t, float>(b, &stack);
+      break;
+
+    case Opcode::I32TruncSatF64S:
+      EmitSaturatingTruncation<int32_t, double>(b, &stack);
+      break;
+
+
+    case Opcode::I32TruncSatF64U:
+      EmitUnsignedSaturatingTruncation<uint32_t, double>(b, &stack);
+      break;
+
+    case Opcode::I64TruncSatF32S:
+      EmitSaturatingTruncation<int64_t, float>(b, &stack);
+      break;
+
+//    UNSIGNED TYPE NOT HANDLED
+//    case Opcode::I64TruncSatF32U:
+//      EmitSaturatingTruncation<uint64_t, float>(b, &stack);
+//      break;
+
+    case Opcode::I64TruncSatF64S:
+      EmitSaturatingTruncation<int64_t, double>(b, &stack);
+      break;
+
+//    UNSIGNED TYPE NOT HANDLED
+//    case Opcode::I64TruncSatF64U:
+//      EmitSaturatingTruncation<uint64_t, double>(b, &stack);
 //      break;
 
     case Opcode::InterpBrUnless: {

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -99,6 +99,11 @@ class FunctionBuilder : public TR::MethodBuilder {
   template <typename ToType, typename FromType>
   void EmitUnsignedTruncation(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack);
 
+  template <typename ToType, typename FromType>
+  void EmitSaturatingTruncation(TR::IlBuilder* b, VirtualStack* stack);
+  template <typename ToType, typename FromType>
+  void EmitUnsignedSaturatingTruncation(TR::IlBuilder* b, VirtualStack* stack);
+
   template <typename>
   TR::IlValue* CalculateShiftAmount(TR::IlBuilder* b, TR::IlValue* amount);
 

--- a/test/jit/truncation_saturating.txt
+++ b/test/jit/truncation_saturating.txt
@@ -1,0 +1,299 @@
+;;; TOOL: run-interp-jit
+;;; ARGS*: --enable-saturating-float-to-int
+(module
+  (func $i32_trunc_sat_f32_s (param f32) (result i32)
+    get_local 0
+    i32.trunc_sat_f32_s)
+
+  (func (export "test_i32_trunc_sat_f32_s_0") (result i32)
+    f32.const 0.0
+    call $i32_trunc_sat_f32_s)
+
+  (func (export "test_i32_trunc_sat_f32_s_1") (result i32)
+    f32.const 5.99
+    call $i32_trunc_sat_f32_s)
+
+  (func (export "test_i32_trunc_sat_f32_s_2") (result i32)
+    f32.const -5.99
+    call $i32_trunc_sat_f32_s)
+
+  (func (export "test_i32_trunc_sat_f32_s_3") (result i32)
+    f32.const 3e9
+    call $i32_trunc_sat_f32_s)
+
+  (func (export "test_i32_trunc_sat_f32_s_4") (result i32)
+    f32.const -3e9
+    call $i32_trunc_sat_f32_s)
+
+  (func (export "test_i32_trunc_sat_f32_s_5") (result i32)
+    f32.const inf
+    call $i32_trunc_sat_f32_s)
+
+  (func (export "test_i32_trunc_sat_f32_s_6") (result i32)
+    f32.const -inf
+    call $i32_trunc_sat_f32_s)
+
+  (func (export "test_i32_trunc_sat_f32_s_7") (result i32)
+    f32.const nan
+    call $i32_trunc_sat_f32_s)
+
+  (func (export "test_i32_trunc_sat_f32_s_8") (result i32)
+    f32.const -nan
+    call $i32_trunc_sat_f32_s)
+
+  (func $i32_trunc_sat_f32_u (param f32) (result i32)
+    get_local 0
+    i32.trunc_sat_f32_u)
+
+  (func (export "test_i32_trunc_sat_f32_u_0") (result i32)
+    f32.const 0.0
+    call $i32_trunc_sat_f32_u)
+
+  (func (export "test_i32_trunc_sat_f32_u_1") (result i32)
+    f32.const 5.99
+    call $i32_trunc_sat_f32_u)
+
+  (func (export "test_i32_trunc_sat_f32_u_2") (result i32)
+    f32.const 3e9
+    call $i32_trunc_sat_f32_u)
+
+  (func (export "test_i32_trunc_sat_f32_u_3") (result i32)
+    f32.const 5e9
+    call $i32_trunc_sat_f32_u)
+
+  (func (export "test_i32_trunc_sat_f32_u_4") (result i32)
+    f32.const -1.01
+    call $i32_trunc_sat_f32_u)
+
+  (func (export "test_i32_trunc_sat_f32_u_5") (result i32)
+    f32.const inf
+    call $i32_trunc_sat_f32_u)
+
+  (func (export "test_i32_trunc_sat_f32_u_6") (result i32)
+    f32.const -inf
+    call $i32_trunc_sat_f32_u)
+
+  (func (export "test_i32_trunc_sat_f32_u_7") (result i32)
+    f32.const nan
+    call $i32_trunc_sat_f32_u)
+
+  (func (export "test_i32_trunc_sat_f32_u_8") (result i32)
+    f32.const -nan
+    call $i32_trunc_sat_f32_u)
+
+  (func $i32_trunc_sat_f64_s (param f64) (result i32)
+    get_local 0
+    i32.trunc_sat_f64_s)
+
+  (func (export "test_i32_trunc_sat_f64_s_0") (result i32)
+    f64.const 0.0
+    call $i32_trunc_sat_f64_s)
+
+  (func (export "test_i32_trunc_sat_f64_s_1") (result i32)
+    f64.const 5.99
+    call $i32_trunc_sat_f64_s)
+
+  (func (export "test_i32_trunc_sat_f64_s_2") (result i32)
+    f64.const -5.99
+    call $i32_trunc_sat_f64_s)
+
+  (func (export "test_i32_trunc_sat_f64_s_3") (result i32)
+    f64.const 3e9
+    call $i32_trunc_sat_f64_s)
+
+  (func (export "test_i32_trunc_sat_f64_s_4") (result i32)
+    f64.const -3e9
+    call $i32_trunc_sat_f64_s)
+
+  (func (export "test_i32_trunc_sat_f64_s_5") (result i32)
+    f64.const inf
+    call $i32_trunc_sat_f64_s)
+
+  (func (export "test_i32_trunc_sat_f64_s_6") (result i32)
+    f64.const -inf
+    call $i32_trunc_sat_f64_s)
+
+  (func (export "test_i32_trunc_sat_f64_s_7") (result i32)
+    f64.const nan
+    call $i32_trunc_sat_f64_s)
+
+  (func (export "test_i32_trunc_sat_f64_s_8") (result i32)
+    f64.const -nan
+    call $i32_trunc_sat_f64_s)
+
+  (func $i32_trunc_sat_f64_u (param f64) (result i32)
+    get_local 0
+    i32.trunc_sat_f64_u)
+
+  (func (export "test_i32_trunc_sat_f64_u_0") (result i32)
+    f64.const 0.0
+    call $i32_trunc_sat_f64_u)
+
+  (func (export "test_i32_trunc_sat_f64_u_1") (result i32)
+    f64.const 5.99
+    call $i32_trunc_sat_f64_u)
+
+  (func (export "test_i32_trunc_sat_f64_u_2") (result i32)
+    f64.const 3e9
+    call $i32_trunc_sat_f64_u)
+
+  (func (export "test_i32_trunc_sat_f64_u_3") (result i32)
+    f64.const 5e9
+    call $i32_trunc_sat_f64_u)
+
+  (func (export "test_i32_trunc_sat_f64_u_4") (result i32)
+    f64.const -1.01
+    call $i32_trunc_sat_f64_u)
+
+  (func (export "test_i32_trunc_sat_f64_u_5") (result i32)
+    f64.const inf
+    call $i32_trunc_sat_f64_u)
+
+  (func (export "test_i32_trunc_sat_f64_u_6") (result i32)
+    f64.const -inf
+    call $i32_trunc_sat_f64_u)
+
+  (func (export "test_i32_trunc_sat_f64_u_7") (result i32)
+    f64.const nan
+    call $i32_trunc_sat_f64_u)
+
+  (func (export "test_i32_trunc_sat_f64_u_8") (result i32)
+    f64.const -nan
+    call $i32_trunc_sat_f64_u)
+
+  (func $i64_trunc_sat_f32_s (param f32) (result i64)
+    get_local 0
+    i64.trunc_sat_f32_s)
+
+  (func (export "test_i64_trunc_sat_f32_s_0") (result i64)
+    f32.const 0.0
+    call $i64_trunc_sat_f32_s)
+
+  (func (export "test_i64_trunc_sat_f32_s_1") (result i64)
+    f32.const 5.99
+    call $i64_trunc_sat_f32_s)
+
+  (func (export "test_i64_trunc_sat_f32_s_2") (result i64)
+    f32.const -5.99
+    call $i64_trunc_sat_f32_s)
+
+  (func (export "test_i64_trunc_sat_f32_s_3") (result i64)
+    f32.const 1e19
+    call $i64_trunc_sat_f32_s)
+
+  (func (export "test_i64_trunc_sat_f32_s_4") (result i64)
+    f32.const -1e19
+    call $i64_trunc_sat_f32_s)
+
+  (func (export "test_i64_trunc_sat_f32_s_5") (result i64)
+    f32.const inf
+    call $i64_trunc_sat_f32_s)
+
+  (func (export "test_i64_trunc_sat_f32_s_6") (result i64)
+    f32.const -inf
+    call $i64_trunc_sat_f32_s)
+
+  (func (export "test_i64_trunc_sat_f32_s_7") (result i64)
+    f32.const nan
+    call $i64_trunc_sat_f32_s)
+
+  (func (export "test_i64_trunc_sat_f32_s_8") (result i64)
+    f32.const -nan
+    call $i64_trunc_sat_f32_s)
+
+  (func $i64_trunc_sat_f64_s (param f64) (result i64)
+    get_local 0
+    i64.trunc_sat_f64_s)
+
+  (func (export "test_i64_trunc_sat_f64_s_0") (result i64)
+    f64.const 0.0
+    call $i64_trunc_sat_f64_s)
+
+  (func (export "test_i64_trunc_sat_f64_s_1") (result i64)
+    f64.const 5.99
+    call $i64_trunc_sat_f64_s)
+
+  (func (export "test_i64_trunc_sat_f64_s_2") (result i64)
+    f64.const -5.99
+    call $i64_trunc_sat_f64_s)
+
+  (func (export "test_i64_trunc_sat_f64_s_3") (result i64)
+    f64.const 1e19
+    call $i64_trunc_sat_f64_s)
+
+  (func (export "test_i64_trunc_sat_f64_s_4") (result i64)
+    f64.const -1e19
+    call $i64_trunc_sat_f64_s)
+
+  (func (export "test_i64_trunc_sat_f64_s_5") (result i64)
+    f64.const inf
+    call $i64_trunc_sat_f64_s)
+
+  (func (export "test_i64_trunc_sat_f64_s_6") (result i64)
+    f64.const -inf
+    call $i64_trunc_sat_f64_s)
+
+  (func (export "test_i64_trunc_sat_f64_s_7") (result i64)
+    f64.const nan
+    call $i64_trunc_sat_f64_s)
+
+  (func (export "test_i64_trunc_sat_f64_s_8") (result i64)
+    f64.const -nan
+    call $i64_trunc_sat_f64_s)
+)
+(;; STDOUT ;;;
+test_i32_trunc_sat_f32_s_0() => i32:0
+test_i32_trunc_sat_f32_s_1() => i32:5
+test_i32_trunc_sat_f32_s_2() => i32:4294967291
+test_i32_trunc_sat_f32_s_3() => i32:2147483647
+test_i32_trunc_sat_f32_s_4() => i32:2147483648
+test_i32_trunc_sat_f32_s_5() => i32:2147483647
+test_i32_trunc_sat_f32_s_6() => i32:2147483648
+test_i32_trunc_sat_f32_s_7() => i32:0
+test_i32_trunc_sat_f32_s_8() => i32:0
+test_i32_trunc_sat_f32_u_0() => i32:0
+test_i32_trunc_sat_f32_u_1() => i32:5
+test_i32_trunc_sat_f32_u_2() => i32:3000000000
+test_i32_trunc_sat_f32_u_3() => i32:4294967295
+test_i32_trunc_sat_f32_u_4() => i32:0
+test_i32_trunc_sat_f32_u_5() => i32:4294967295
+test_i32_trunc_sat_f32_u_6() => i32:0
+test_i32_trunc_sat_f32_u_7() => i32:0
+test_i32_trunc_sat_f32_u_8() => i32:0
+test_i32_trunc_sat_f64_s_0() => i32:0
+test_i32_trunc_sat_f64_s_1() => i32:5
+test_i32_trunc_sat_f64_s_2() => i32:4294967291
+test_i32_trunc_sat_f64_s_3() => i32:2147483647
+test_i32_trunc_sat_f64_s_4() => i32:2147483648
+test_i32_trunc_sat_f64_s_5() => i32:2147483647
+test_i32_trunc_sat_f64_s_6() => i32:2147483648
+test_i32_trunc_sat_f64_s_7() => i32:0
+test_i32_trunc_sat_f64_s_8() => i32:0
+test_i32_trunc_sat_f64_u_0() => i32:0
+test_i32_trunc_sat_f64_u_1() => i32:5
+test_i32_trunc_sat_f64_u_2() => i32:3000000000
+test_i32_trunc_sat_f64_u_3() => i32:4294967295
+test_i32_trunc_sat_f64_u_4() => i32:0
+test_i32_trunc_sat_f64_u_5() => i32:4294967295
+test_i32_trunc_sat_f64_u_6() => i32:0
+test_i32_trunc_sat_f64_u_7() => i32:0
+test_i32_trunc_sat_f64_u_8() => i32:0
+test_i64_trunc_sat_f32_s_0() => i64:0
+test_i64_trunc_sat_f32_s_1() => i64:5
+test_i64_trunc_sat_f32_s_2() => i64:18446744073709551611
+test_i64_trunc_sat_f32_s_3() => i64:9223372036854775807
+test_i64_trunc_sat_f32_s_4() => i64:9223372036854775808
+test_i64_trunc_sat_f32_s_5() => i64:9223372036854775807
+test_i64_trunc_sat_f32_s_6() => i64:9223372036854775808
+test_i64_trunc_sat_f32_s_7() => i64:0
+test_i64_trunc_sat_f32_s_8() => i64:0
+test_i64_trunc_sat_f64_s_0() => i64:0
+test_i64_trunc_sat_f64_s_1() => i64:5
+test_i64_trunc_sat_f64_s_2() => i64:18446744073709551611
+test_i64_trunc_sat_f64_s_3() => i64:9223372036854775807
+test_i64_trunc_sat_f64_s_4() => i64:9223372036854775808
+test_i64_trunc_sat_f64_s_5() => i64:9223372036854775807
+test_i64_trunc_sat_f64_s_6() => i64:9223372036854775808
+test_i64_trunc_sat_f64_s_7() => i64:0
+test_i64_trunc_sat_f64_s_8() => i64:0
+;;; STDOUT ;;)


### PR DESCRIPTION
The following opcodes for performing saturating conversions from
floating-point types to integral types have now been implemented:

- `i32.trunc_sat_f32_s`
- `i32.trunc_sat_f32_u`
- `i32.trunc_sat_f64_s`
- `i32.trunc_sat_f64_u`
- `i64.trunc_sat_f32_s`
- `i64.trunc_sat_f64_s`

Note that conversions from floating-point types to unsigned 64-bit
integers have not yet been implemented due to lacking support in OMR.
See #147 for more details.

Closes #139