### PR TITLE
Fix incorrect stack traces for failed JIT compilations

### DIFF
--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1556,6 +1556,8 @@ class TempPc {
 Result Thread::Run(int num_instructions) {
   Result result = Result::Ok;
 
+  this->in_jit_ = false;
+
   TempPc tpc(this);
   const uint8_t*& istream = tpc.istream;
   const uint8_t*& pc = tpc.pc;

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -541,11 +541,13 @@ class Environment {
 };
 
 struct CallFrame {
-  CallFrame() : pc(0), is_jit(false) {}
-  CallFrame(IstreamOffset pc, bool is_jit) : pc(pc), is_jit(is_jit) {}
+  CallFrame() : pc(0), is_jit(false), is_jit_compiling(false) {}
+  CallFrame(IstreamOffset pc, bool is_jit, bool is_jit_compiling = false)
+    : pc(pc), is_jit(is_jit), is_jit_compiling(is_jit_compiling) {}
 
   IstreamOffset pc;
   bool is_jit;
+  bool is_jit_compiling;
 };
 
 class Thread {

--- a/test/jit/stack_trace.txt
+++ b/test/jit/stack_trace.txt
@@ -1,0 +1,150 @@
+;;; TOOL: run-interp-minimal
+;;; ARGS0: --debug-names
+(module
+  ;; TODO: Find a better way to prevent JIT compilation than using memory.size
+  ;; TODO: Find a way to avoid baking in function offsets
+  (memory 0)
+  (table anyfunc (elem $jit_crash $interp_crash $jit_nop $interp_nop))
+
+  (func $jit_crash
+    unreachable)
+  (func $interp_crash
+    memory.size
+    drop
+    unreachable)
+
+  (func $jit_nop)
+  (func $interp_nop
+    memory.size
+    drop)
+
+  (func (export "test_interp2interp_direct")
+    call $interp_crash)
+
+  (func (export "test_interp2jit_direct")
+    call $jit_crash)
+
+  (func $jit2interp_direct
+    call $interp_crash)
+  (func (export "test_jit2interp_direct")
+    call $jit2interp_direct)
+
+  (func $jit2jit_direct
+    call $jit_crash)
+  (func (export "test_jit2jit_direct")
+    call $jit2jit_direct)
+
+  (func (export "test_interp2interp_indirect")
+    i32.const 1
+    call_indirect)
+
+  (func (export "test_interp2jit_indirect")
+    i32.const 0
+    call_indirect)
+
+  (func $jit2interp_indirect
+    i32.const 1
+    call_indirect)
+  (func (export "test_jit2interp_indirect")
+    call $jit2interp_indirect)
+
+  (func $jit2jit_indirect
+    i32.const 0
+    call_indirect)
+  (func (export "test_jit2jit_indirect")
+    call $jit2jit_indirect)
+
+  (func (export "test_interp_indirect_fail")
+    i32.const -1
+    call_indirect)
+
+  (func $jit_indirect_fail
+    i32.const -1
+    call_indirect)
+  (func (export "test_jit_indirect_fail")
+    call $jit_indirect_fail)
+
+  (func (export "test_interp2interp_after_interp2jit_direct")
+    call $jit_nop
+    call $interp_crash)
+
+  (func $jit2jit_after_jit2interp_direct
+    call $interp_nop
+    call $jit_crash)
+  (func (export "test_jit2jit_after_jit2interp_direct")
+    call $jit2jit_after_jit2interp_direct)
+
+  (func (export "test_interp2interp_after_interp2jit_indirect")
+    i32.const 2
+    call_indirect
+    i32.const 1
+    call_indirect)
+
+  (func $jit2jit_after_jit2interp_indirect
+    i32.const 3
+    call_indirect
+    i32.const 0
+    call_indirect)
+  (func (export "test_jit2jit_after_jit2interp_indirect")
+    call $jit2jit_after_jit2interp_indirect)
+)
+(;; STDOUT ;;;
+test_interp2interp_direct() => error: unreachable executed
+  at $interp_crash + 0x10
+  at test_interp2interp_direct + 0x8
+test_interp2jit_direct() => error: unreachable executed
+  at $jit_crash + 0x4
+[Interpreter to JIT transition]
+  at test_interp2jit_direct + 0x8
+test_jit2interp_direct() => error: unreachable executed
+  at $interp_crash + 0x10
+[JIT to interpreter transition]
+  at $jit2interp_direct + 0x8
+[Interpreter to JIT transition]
+  at test_jit2interp_direct + 0x8
+test_jit2jit_direct() => error: unreachable executed
+  at $jit_crash + 0x4
+  at $jit2jit_direct + 0x8
+[Interpreter to JIT transition]
+  at test_jit2jit_direct + 0x8
+test_interp2interp_indirect() => error: unreachable executed
+  at $interp_crash + 0x10
+  at test_interp2interp_indirect + 0x14
+test_interp2jit_indirect() => error: unreachable executed
+  at $jit_crash + 0x4
+[Interpreter to JIT transition]
+  at test_interp2jit_indirect + 0x14
+test_jit2interp_indirect() => error: unreachable executed
+  at $interp_crash + 0x10
+[JIT to interpreter transition]
+  at $jit2interp_indirect + 0x14
+[Interpreter to JIT transition]
+  at test_jit2interp_indirect + 0x8
+test_jit2jit_indirect() => error: unreachable executed
+  at $jit_crash + 0x4
+  at $jit2jit_indirect + 0x14
+[Interpreter to JIT transition]
+  at test_jit2jit_indirect + 0x8
+test_interp_indirect_fail() => error: undefined table index
+  at test_interp_indirect_fail + 0x14
+test_jit_indirect_fail() => error: undefined table index
+  at $jit_indirect_fail + 0x14
+[Interpreter to JIT transition]
+  at test_jit_indirect_fail + 0x8
+test_interp2interp_after_interp2jit_direct() => error: unreachable executed
+  at $interp_crash + 0x10
+  at test_interp2interp_after_interp2jit_direct + 0x10
+test_jit2jit_after_jit2interp_direct() => error: unreachable executed
+  at $jit_crash + 0x4
+  at $jit2jit_after_jit2interp_direct + 0x10
+[Interpreter to JIT transition]
+  at test_jit2jit_after_jit2interp_direct + 0x8
+test_interp2interp_after_interp2jit_indirect() => error: unreachable executed
+  at $interp_crash + 0x10
+  at test_interp2interp_after_interp2jit_indirect + 0x28
+test_jit2jit_after_jit2interp_indirect() => error: unreachable executed
+  at $jit_crash + 0x4
+  at $jit2jit_after_jit2interp_indirect + 0x28
+[Interpreter to JIT transition]
+  at test_jit2jit_after_jit2interp_indirect + 0x8
+;;; STDOUT ;;)

--- a/test/jit/stack_trace_comp_fail.txt
+++ b/test/jit/stack_trace_comp_fail.txt
@@ -1,0 +1,56 @@
+;;; TOOL: run-interp-minimal
+;;; ARGS0: --debug-names
+;;; ARGS1: --trap-on-failed-comp
+(module
+  ;; These tests must be in a different test file than those from stack_trace.txt since they rely on
+  ;; the --trap-on-failed-comp command line option in order to cause a JIT compilation failure trap.
+  ;; stack_trace.txt cannot have this option set since it tests functionality which requires JITted
+  ;; functions to call interpreted functions.
+
+  ;; TODO: Find a better way to prevent JIT compilation than using memory.size
+  ;; TODO: Find a way to avoid baking in function offsets
+  (memory 0)
+  (table anyfunc (elem $jit_fail))
+
+  (func $jit_fail
+    memory.size
+    drop)
+
+  (func (export "test_interp_direct_comp_fail")
+    call $jit_fail)
+
+  (func (export "test_interp_indirect_comp_fail")
+    i32.const 0
+    call_indirect)
+
+  (func $jit_direct_comp_fail
+    call $jit_fail
+    unreachable)
+  (func (export "test_jit_direct_comp_fail")
+    call $jit_direct_comp_fail)
+
+  (func $jit_indirect_comp_fail
+    i32.const 0
+    call_indirect
+    unreachable)
+  (func (export "test_jit_indirect_comp_fail")
+    call $jit_indirect_comp_fail)
+)
+(;; STDOUT ;;;
+test_interp_direct_comp_fail() => error: failed JIT compilation
+  at $jit_fail (during JIT compilation)
+  at test_interp_direct_comp_fail + 0x8
+test_interp_indirect_comp_fail() => error: failed JIT compilation
+  at $jit_fail (during JIT compilation)
+  at test_interp_indirect_comp_fail + 0x14
+test_jit_direct_comp_fail() => error: failed JIT compilation
+  at $jit_fail (during JIT compilation)
+  at $jit_direct_comp_fail + 0x8
+[Interpreter to JIT transition]
+  at test_jit_direct_comp_fail + 0x8
+test_jit_indirect_comp_fail() => error: failed JIT compilation
+  at $jit_fail (during JIT compilation)
+  at $jit_indirect_comp_fail + 0x14
+[Interpreter to JIT transition]
+  at test_jit_indirect_comp_fail + 0x8
+;;; STDOUT ;;)

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -93,6 +93,11 @@ TOOLS = {
         ('RUN', '%(wasm-interp)s %(temp_file)s.wasm --run-all-exports --trap-on-failed-comp --no-stack-trace'),
         ('VERBOSE-ARGS', ['--print-cmd', '-v']),
     ],
+    'run-interp-minimal': [
+        ('RUN', '%(wat2wasm)s %(in_file)s -o %(temp_file)s.wasm'),
+        ('RUN', '%(wasm-interp)s %(temp_file)s.wasm --run-all-exports'),
+        ('VERBOSE-ARGS', ['--print-cmd', '-v']),
+    ],
     'run-interp-spec': [
         ('RUN', '%(wast2json)s %(in_file)s -o %(temp_file)s.json'),
         ('RUN', '%(spectest-interp)s %(temp_file)s.json'),


### PR DESCRIPTION
This PR fixes an issue with incorrect stack traces being generated for failed JIT compilations for calls from JITted functions (#135) by standardizing on including a call frame for the function being compiled and adding a note to the stack trace that this function was being compiled. This not only fixes the original issue, but also makes it more clear which function actually caused the trap.

In order to prevent regressions, this PR also adds tests that test that stack traces are generated correctly. To make this easier, the format of stack traces has also been slightly tweaked to use offsets relative from the start of the function rather than offsets relative to the start of the instruction buffer.