### PR TITLE
Fix virtual stack merging

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(wabtjit STATIC
   function-builder.cc
   wabtjit.cc
   stack.cc
+  vms_hack.cc
 )
 
 # Mark JitBuilder include directories as "system" include directories. For most compilers, this

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -30,9 +30,14 @@
 namespace wabt {
 namespace jit {
 
+// Workaround for broken JitBuilder callbacks. See vms_hack.cc for more details.
+void initializeVmsHack(TR::VirtualMachineState* vms);
+
 class WabtState : public TR::VirtualMachineState {
 public:
   VirtualStack stack;
+
+  WabtState() { initializeVmsHack(this); }
 
   VirtualMachineState* MakeCopy() override {
     return new WabtState(*this);

--- a/src/jit/vms_hack.cc
+++ b/src/jit/vms_hack.cc
@@ -1,0 +1,26 @@
+#include <cstddef>
+#include "JitBuilder.hpp"
+#include "ilgen/VirtualMachineState.hpp"
+
+// This file contains hacky nonsense that makes VirtualMachineState work correctly because
+// *somebody* decided not to have a fallback for if no client callback was registered for
+// VirtualMachineState::MergeInto. So we have to manually register a passthrough callback that
+// simply calls VirtualMachineState::MergeInto on the implementation object. If we don't do this,
+// then WabtState::MergeInto will simply never be called, breaking a bunch of stuff.
+//
+// This hack should be removed as soon as either JitBuilder fixes this nonsense or we update to
+// using the client API.
+
+namespace wabt {
+namespace jit {
+
+static void vmsHack_MergeInto(OMR::JitBuilder::VirtualMachineState* self, OMR::JitBuilder::VirtualMachineState* other, OMR::JitBuilder::IlBuilder* b) {
+  static_cast<TR::VirtualMachineState*>(self->_impl)->MergeInto(static_cast<TR::VirtualMachineState*>(other->_impl), static_cast<TR::IlBuilder*>(b->_impl));
+}
+
+void initializeVmsHack(TR::VirtualMachineState* vms) {
+  vms->setClientCallback_MergeInto(reinterpret_cast<void*>(vmsHack_MergeInto));
+}
+
+}
+}

--- a/test/jit/brif_brunless.txt
+++ b/test/jit/brif_brunless.txt
@@ -78,6 +78,22 @@
   (func (export "test_if_with_arg_1") (result i32)
     i32.const 1
     call $if_with_arg)
+
+  (func $if_with_result (param i32) (result i32)
+    get_local 0
+    if (result i32)
+      i32.const 1
+    else
+      i32.const 0
+    end)
+
+  (func (export "test_if_with_result_0") (result i32)
+    i32.const 0
+    call $if_with_result)
+
+  (func (export "test_if_with_result_1") (result i32)
+    i32.const 1
+    call $if_with_result)
 )
 (;; STDOUT ;;;
 test_brif_always_true() => i32:1
@@ -88,5 +104,7 @@ test_if_always_true() => i32:1
 test_if_always_false() => i32:0
 test_if_with_arg_0() => i32:0
 test_if_with_arg_1() => i32:1
+test_if_with_result_0() => i32:0
+test_if_with_result_1() => i32:1
 ;;; STDOUT ;;)
 

--- a/test/jit/multi_value.txt
+++ b/test/jit/multi_value.txt
@@ -1,0 +1,130 @@
+;;; TOOL: run-interp-jit
+;;; ARGS*: --enable-multi-value
+(module
+  (func $test_multi_return_callee (result i32 i32)
+    i32.const 1
+    i32.const 5)
+  (func $test_multi_return_caller (result i32)
+    call $test_multi_return_callee
+    i32.add)
+
+  (func (export "test_multi_return_interp2jit") (result i32 i32)
+    call $test_multi_return_callee)
+  (func (export "test_multi_return_jit2jit") (result i32)
+    call $test_multi_return_caller)
+
+  (func $multi_block_result (result i32 i32)
+    i32.const 10
+    block (param i32) (result i32 i32)
+      i32.const 5
+      i32.add
+      i32.const 10
+    end)
+  (func (export "test_multi_block_result") (result i32 i32)
+    call $multi_block_result)
+
+  (func $multi_block_result_br (result i32 i32)
+    block (result i32 i32)
+      i32.const 2
+      i32.const 3
+      br 0
+    end)
+  (func (export "test_multi_block_result_br") (result i32 i32)
+    call $multi_block_result_br)
+
+  (func $multi_block_result_br_if (param i32) (result i32 i32)
+    block (result i32 i32)
+      i32.const 0
+      i32.const 1
+      get_local 0
+      br_if 0
+      drop
+      drop
+      i32.const 2
+      i32.const 3
+    end)
+  (func (export "test_multi_block_result_br_if_0") (result i32 i32)
+    i32.const 0
+    call $multi_block_result_br_if)
+  (func (export "test_multi_block_result_br_if_1") (result i32 i32)
+    i32.const 1
+    call $multi_block_result_br_if)
+
+  (func $multi_block_param (result i32)
+    i32.const 10
+    i32.const 5
+    block (param i32 i32) (result i32)
+      i32.add
+    end)
+  (func (export "test_multi_block_param") (result i32)
+    call $multi_block_param)
+
+  (func $multi_if_param (param i32) (result i32)
+    i32.const 10
+    i32.const 5
+    get_local 0
+    if (param i32 i32) (result i32)
+      i32.add
+    else
+      i32.mul
+    end)
+  (func (export "test_multi_if_param_0") (result i32)
+    i32.const 0
+    call $multi_if_param)
+  (func (export "test_multi_if_param_1") (result i32)
+    i32.const 1
+    call $multi_if_param)
+
+  (func $multi_if_result (param i32) (result i32 i32)
+    get_local 0
+    if (result i32 i32)
+      i32.const 0
+      i32.const 1
+    else
+      i32.const 2
+      i32.const 3
+    end)
+  (func (export "test_multi_if_result_0") (result i32 i32)
+    i32.const 0
+    call $multi_if_result)
+  (func (export "test_multi_if_result_1") (result i32 i32)
+    i32.const 1
+    call $multi_if_result)
+
+  (func $multi_loop_result (param i32) (result i32 i32) (local i32)
+    i32.const 0
+    get_local 0
+    loop (param i32 i32) (result i32 i32)
+      i32.const -1
+      i32.add
+      set_local 1
+      i32.const 2
+      i32.add
+      get_local 1
+      get_local 1
+      i32.const 0
+      i32.ne
+      br_if 0
+    end)
+  (func (export "test_multi_loop_result_0") (result i32 i32)
+    i32.const 3
+    call $multi_loop_result)
+  (func (export "test_multi_loop_result_1") (result i32 i32)
+    i32.const 5
+    call $multi_loop_result)
+)
+(;; STDOUT ;;;
+test_multi_return_interp2jit() => i32:1, i32:5
+test_multi_return_jit2jit() => i32:6
+test_multi_block_result() => i32:15, i32:10
+test_multi_block_result_br() => i32:2, i32:3
+test_multi_block_result_br_if_0() => i32:2, i32:3
+test_multi_block_result_br_if_1() => i32:0, i32:1
+test_multi_block_param() => i32:15
+test_multi_if_param_0() => i32:50
+test_multi_if_param_1() => i32:15
+test_multi_if_result_0() => i32:2, i32:3
+test_multi_if_result_1() => i32:0, i32:1
+test_multi_loop_result_0() => i32:6, i32:0
+test_multi_loop_result_1() => i32:10, i32:0
+;;; STDOUT ;;)


### PR DESCRIPTION
Due to changes in upstream OMR when adding the JitBuilder client API, virtual stack merging silently stopped working, as reported in #151. Additionally, it turns out that there was no test coverage for this functionality, which allowed this failure to go undetected for an extended length of time. This PR fixes the problem using an incredibly hacky workaround and adds tests that should detect breakage in the future, including in multi-value scenarios. This hacky workaround should be removed as soon as it is possible to do so.