### PR TITLE
Use IlValues to represent locals when compiling functions

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(wabtjit STATIC
 
 # Mark JitBuilder include directories as "system" include directories. For most compilers, this
 # suppresses any warnings they would otherwise generate.
-set(JITBUILDER_EXTRA_INCLUDE ${CMAKE_SOURCE_DIR}/third_party/omr/compiler ${CMAKE_SOURCE_DIR}/third_party/omr)
+set(JITBUILDER_EXTRA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/omr/compiler ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/omr)
 get_property(JITBUILDER_INCLUDE TARGET jitbuilder PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(wabtjit SYSTEM PUBLIC "${JITBUILDER_INCLUDE}")
 target_include_directories(wabtjit SYSTEM PUBLIC "${JITBUILDER_EXTRA_INCLUDE}")

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -62,9 +62,8 @@ class FunctionBuilder : public TR::MethodBuilder {
       : builder(builder), pc(pc) {}
   };
 
-  void SetUpLocals(TR::IlBuilder* b, const uint8_t** pc, VirtualStack* stack);
+  bool SetUpLocals(TR::IlBuilder* b, const uint8_t** pc, VirtualStack* stack);
   void TearDownLocals(TR::IlBuilder* b);
-  uint32_t GetLocalOffset(VirtualStack* stack, Type* type, uint32_t depth);
 
   void MoveToPhysStack(TR::IlBuilder* b, const uint8_t* pc, VirtualStack* stack, uint32_t depth);
   void MoveFromPhysStack(TR::IlBuilder* b, VirtualStack* stack, const std::vector<Type>& types);


### PR DESCRIPTION
Previously, access to locals was represented by doing indirect memory accesses to the physical stack (where the interpreter stores function locals). Now, locals are represented as IlValues on the virtual stack, removing the need for the indirection at runtime. Since locals are not visible outside of a function's frame, there is no need to restore the state of locals on transitions to/from the interpreter. In addition, parameters are also "loaded" as IlValues at the beginning of functions and stored on the virtual stack for later use.