### PR TITLE
Fix JitBuilder include path

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(wabtjit STATIC
 
 # Mark JitBuilder include directories as "system" include directories. For most compilers, this
 # suppresses any warnings they would otherwise generate.
-set(JITBUILDER_EXTRA_INCLUDE ${CMAKE_SOURCE_DIR}/third_party/omr/compiler ${CMAKE_SOURCE_DIR}/third_party/omr)
+set(JITBUILDER_EXTRA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/omr/compiler ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/omr)
 get_property(JITBUILDER_INCLUDE TARGET jitbuilder PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(wabtjit SYSTEM PUBLIC "${JITBUILDER_INCLUDE}")
 target_include_directories(wabtjit SYSTEM PUBLIC "${JITBUILDER_EXTRA_INCLUDE}")


### PR DESCRIPTION
Previously, the CMakeLists.txt file for the JIT was setting the
JitBuilder include directory relative to ${CMAKE_SOURCE_DIR}. While this
was correct when building wasmjit-omr on its own, it is not correct if
wasmjit-omr is being included in another CMake project through the use
of add_subdirectory. Instead, using ${CMAKE_CURRENT_SOURCE_DIR} to set
the JitBuilder include path will do the right thing for all use cases.