### PR TITLE
Improve function dispatch from JITted code

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1203,9 +1203,6 @@ wabt::Result BinaryReaderInterp::BeginFunctionBody(Index index, Offset size) {
   func->local_decl_count = 0;
   func->local_count = 0;
 
-  /* wasmjit-omr: emit JIT metadata now that func->offset is known */
-  env_->AddJitMetadata(func);
-
   current_func_ = func;
   depth_fixups_.clear();
   label_stack_.clear();

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1489,11 +1489,10 @@ wabt::Result BinaryReaderInterp::OnCallExpr(Index func_index) {
 
   if (func->is_host) {
     CHECK_RESULT(EmitOpcode(Opcode::InterpCallHost));
-    CHECK_RESULT(EmitI32(TranslateFuncIndexToEnv(func_index)));
   } else {
     CHECK_RESULT(EmitOpcode(Opcode::Call));
-    CHECK_RESULT(EmitFuncOffset(cast<DefinedFunc>(func), func_index));
   }
+  CHECK_RESULT(EmitI32(TranslateFuncIndexToEnv(func_index)));
 
   return wabt::Result::Ok;
 }
@@ -1531,7 +1530,7 @@ wabt::Result BinaryReaderInterp::OnReturnCallExpr(Index func_index) {
     CHECK_RESULT(EmitOpcode(Opcode::Return));
   } else {
     CHECK_RESULT(EmitOpcode(Opcode::ReturnCall));
-    CHECK_RESULT(EmitFuncOffset(cast<DefinedFunc>(func), func_index));
+    CHECK_RESULT(EmitI32(TranslateFuncIndexToEnv(func_index)));
   }
 
   return wabt::Result::Ok;

--- a/src/interp/interp-disassemble.cc
+++ b/src/interp/interp-disassemble.cc
@@ -107,7 +107,7 @@ void Environment::Disassemble(Stream* stream,
 
       case Opcode::Call:
       case Opcode::ReturnCall:
-        stream->Writef("%s @%u\n", opcode.GetName(), ReadU32(&pc));
+        stream->Writef("%s $%u\n", opcode.GetName(), ReadU32(&pc));
         break;
 
       case Opcode::CallIndirect:

--- a/src/interp/interp-trace.cc
+++ b/src/interp/interp-trace.cc
@@ -103,7 +103,7 @@ void Thread::Trace(Stream* stream) {
 
     case Opcode::Call:
     case Opcode::ReturnCall:
-      stream->Writef("%s @%u\n", opcode.GetName(), ReadU32At(pc));
+      stream->Writef("%s $%u\n", opcode.GetName(), ReadU32At(pc));
       break;
 
     case Opcode::CallIndirect:

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1829,7 +1829,7 @@ Result Thread::Run(int num_instructions) {
         break;
 
       case Opcode::Call: {
-        IstreamOffset offset = ReadU32(&pc);
+        IstreamOffset offset = cast<DefinedFunc>(env_->GetFunc(ReadU32(&pc)))->offset;
         Environment::JITedFunction jit_fn;
 
         CHECK_TRAP(PushCall(pc));
@@ -1900,7 +1900,7 @@ Result Thread::Run(int num_instructions) {
       }
 
       case Opcode::ReturnCall: {
-        IstreamOffset offset = ReadU32(&pc);
+        IstreamOffset offset = cast<DefinedFunc>(env_->GetFunc(ReadU32(&pc)))->offset;
         GOTO(offset);
 
         break;

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -27,6 +27,8 @@
 #include <unordered_map>
 
 #include "src/jit/environment.h"
+#include "src/jit/thread.h"
+#include "src/jit/thunk.h"
 #include "src/binding-hash.h"
 #include "src/common.h"
 #include "src/opcode.h"
@@ -498,7 +500,11 @@ class Environment {
   template <typename... Args>
   Func* EmplaceBackFunc(Args&&... args) {
     funcs_.emplace_back(std::forward<Args>(args)...);
-    return funcs_.back().get();
+    jit_funcs_.emplace_back(funcs_.back()->is_host ? jit::HostCallThunk : jit::InterpThunk);
+
+    Func* f = funcs_.back().get();
+
+    return f;
   }
 
   template <typename... Args>
@@ -560,8 +566,10 @@ class Environment {
  private:
   friend class Thread;
   friend class wabt::jit::FunctionBuilder;
+  friend jit::Result_t jit::InterpThunk(jit::ThreadInfo*, Index);
+  friend jit::Result_t jit::HostCallThunk(jit::ThreadInfo*, Index);
 
-  Result TryJit(Thread* t, DefinedFunc* fn);
+  Result TryJit(Thread* t, DefinedFunc* fn, Index ind);
 
   std::vector<std::unique_ptr<Module>> modules_;
   std::vector<FuncSignature> sigs_;
@@ -575,6 +583,7 @@ class Environment {
   BindingHash module_bindings_;
   BindingHash registered_module_bindings_;
 
+  std::vector<jit::JITedFunction> jit_funcs_;
   jit::JitEnvironment jit_env_;
 };
 
@@ -584,8 +593,8 @@ struct CallFrame {
     : pc(pc), is_jit(is_jit), is_jit_compiling(is_jit_compiling) {}
 
   IstreamOffset pc;
-  bool is_jit;
-  bool is_jit_compiling;
+  int8_t is_jit;
+  int8_t is_jit_compiling;
 };
 
 class Thread {
@@ -620,7 +629,8 @@ class Thread {
   Result CallHost(HostFunc*);
 
  private:
-  friend class wabt::jit::FunctionBuilder;
+  friend class jit::FunctionBuilder;
+  friend jit::Result_t jit::InterpThunk(jit::ThreadInfo*, Index);
   friend class Executor;
   const uint8_t* GetIstream() const { return env_->istream_->data.data(); }
 
@@ -713,6 +723,8 @@ class Thread {
   uint32_t last_jit_frame_ = 0;
   IstreamOffset pc_ = 0;
   bool in_jit_ = false;
+
+  std::unique_ptr<jit::ThreadInfo> jit_th_;
 };
 
 struct ExecResult {

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(wabtjit STATIC
   wabtjit.cc
   stack.cc
   vms_hack.cc
+  thunk.cc
 )
 
 # Mark JitBuilder include directories as "system" include directories. For most compilers, this

--- a/src/jit/environment.h
+++ b/src/jit/environment.h
@@ -17,13 +17,17 @@
 #ifndef JIT_ENVIRONMENT_HPP
 #define JIT_ENVIRONMENT_HPP
 
+#include "src/common.h"
+
 #include <cstdint>
 
 namespace wabt {
 namespace jit {
 
+struct ThreadInfo;
+
 using Result_t = int32_t;
-using JITedFunction = Result_t (*)();
+using JITedFunction = Result_t (*)(ThreadInfo*, Index);
 
 class JitEnvironment {
 public:

--- a/src/jit/environment.h
+++ b/src/jit/environment.h
@@ -17,8 +17,13 @@
 #ifndef JIT_ENVIRONMENT_HPP
 #define JIT_ENVIRONMENT_HPP
 
+#include <cstdint>
+
 namespace wabt {
 namespace jit {
+
+using Result_t = int32_t;
+using JITedFunction = Result_t (*)();
 
 class JitEnvironment {
 public:

--- a/src/jit/function-builder.cc
+++ b/src/jit/function-builder.cc
@@ -835,7 +835,7 @@ bool FunctionBuilder::Emit(TR::BytecodeBuilder* b,
 
     case Opcode::Call: {
       auto th_addr = b->ConstAddress(thread_);
-      auto offset = interp::ReadU32(&pc);
+      auto offset = cast<interp::DefinedFunc>(thread_->env_->GetFunc(interp::ReadU32(&pc)))->offset;
       auto current_pc = b->Const(pc);
 
       auto meta_it = thread_->env()->jit_meta_.find(offset);

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -27,6 +27,21 @@
 
 #include <type_traits>
 
+#define CHECK_TRAP_HELPER(...)                \
+  do {                                           \
+    wabt::interp::Result result = (__VA_ARGS__); \
+    if (result != wabt::interp::Result::Ok) {    \
+      return static_cast<Result_t>(result);      \
+    }                                            \
+  } while (0)
+#define TRAP_HELPER(type) return static_cast<Result_t>(wabt::interp::Result::Trap##type)
+#define TRAP_UNLESS_HELPER(cond, type) TRAP_IF_HELPER(!(cond), type)
+#define TRAP_IF_HELPER(cond, type)  \
+  do {                       \
+    if (WABT_UNLIKELY(cond)) \
+      TRAP_HELPER(type);            \
+  } while (0)
+
 namespace wabt {
 namespace jit {
 
@@ -112,9 +127,7 @@ class FunctionBuilder : public TR::MethodBuilder {
   template <typename>
   TR::IlValue* CalculateShiftAmount(TR::IlBuilder* b, TR::IlValue* amount);
 
-  static Result_t CallHelper(interp::Thread* th, interp::DefinedFunc* fn, uint8_t* current_pc);
-  static Result_t CallIndirectHelper(wabt::interp::Thread* th, Index table_index, Index sig_index, Index entry_index, uint8_t* current_pc);
-  static Result_t CallHostHelper(wabt::interp::Thread* th, interp::HostFunc* fn);
+  static Result_t CallIndirectHelper(ThreadInfo* th, Index table_index, Index sig_index, Index entry_index);
 
   static void* MemoryTranslationHelper(interp::Thread* th, uint32_t memory_id, uint64_t address, uint32_t size);
 

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -112,13 +112,9 @@ class FunctionBuilder : public TR::MethodBuilder {
   template <typename>
   TR::IlValue* CalculateShiftAmount(TR::IlBuilder* b, TR::IlValue* amount);
 
-  using Result_t = std::underlying_type<wabt::interp::Result>::type;
-
-  static Result_t CallHelper(wabt::interp::Thread* th, wabt::interp::IstreamOffset offset, uint8_t* current_pc);
-
+  static Result_t CallHelper(interp::Thread* th, interp::DefinedFunc* fn, uint8_t* current_pc);
   static Result_t CallIndirectHelper(wabt::interp::Thread* th, Index table_index, Index sig_index, Index entry_index, uint8_t* current_pc);
-
-  static Result_t CallHostHelper(wabt::interp::Thread* th, Index func_index);
+  static Result_t CallHostHelper(wabt::interp::Thread* th, interp::HostFunc* fn);
 
   static void* MemoryTranslationHelper(interp::Thread* th, uint32_t memory_id, uint64_t address, uint32_t size);
 

--- a/src/jit/thread.h
+++ b/src/jit/thread.h
@@ -1,0 +1,30 @@
+#ifndef JIT_THREAD_HPP
+#define JIT_THREAD_HPP
+
+#include "src/common.h"
+#include "environment.h"
+
+namespace wabt {
+namespace interp {
+struct CallFrame;
+class Thread;
+}
+
+namespace jit {
+
+struct ThreadInfo {
+  uint32_t pc;
+  uint32_t in_jit;
+
+  interp::CallFrame* call_stack_max;
+  interp::CallFrame* call_stack;
+
+  JITedFunction* jit_fn_table;
+
+  interp::Thread* thread;
+};
+
+}
+}
+
+#endif // JIT_THREAD_HPP

--- a/src/jit/thunk.cc
+++ b/src/jit/thunk.cc
@@ -1,0 +1,58 @@
+#include "thunk.h"
+#include "function-builder.h"
+#include "thread.h"
+#include "src/cast.h"
+#include "src/interp/interp.h"
+
+namespace wabt {
+namespace jit {
+
+Result_t InterpThunk(ThreadInfo* th, Index ind) {
+  auto* env = th->thread->env();
+  auto* func = cast<interp::DefinedFunc>(env->GetFunc(ind));
+
+  th->pc = func->offset;
+  th->thread->set_pc(func->offset);
+  th->thread->call_stack_top_ = th->call_stack - th->thread->call_stack_.data();
+  CHECK_TRAP_HELPER(env->TryJit(th->thread, func, ind));
+
+  if (func->jit_fn_) {
+    return func->jit_fn_(th, ind);
+  } else {
+    th->thread->in_jit_ = false;
+
+    auto last_jit_frame = th->thread->last_jit_frame_;
+    th->thread->last_jit_frame_ = th->thread->call_stack_top_;
+
+    interp::Result result = interp::Result::Ok;
+    while (result == wabt::interp::Result::Ok) {
+      result = th->thread->Run(1000);
+    }
+    th->thread->last_jit_frame_ = last_jit_frame;
+
+    th->call_stack = th->thread->call_stack_.data() + th->thread->call_stack_top_;
+    if (result != interp::Result::Returned) {
+      th->pc = th->thread->pc_;
+      th->in_jit = th->thread->in_jit_;
+
+      return static_cast<Result_t>(result);
+    }
+
+    th->thread->in_jit_ = true;
+    th->jit_fn_table = th->thread->env()->jit_funcs_.data();
+
+    return static_cast<Result_t>(interp::Result::Ok);
+  }
+}
+
+Result_t HostCallThunk(ThreadInfo* th, Index ind) {
+  auto* func = cast<interp::HostFunc>(th->thread->env()->GetFunc(ind));
+  auto result = th->thread->CallHost(func);
+
+  th->jit_fn_table = th->thread->env()->jit_funcs_.data();
+
+  return static_cast<Result_t>(result);
+}
+
+}
+}

--- a/src/jit/thunk.h
+++ b/src/jit/thunk.h
@@ -1,0 +1,15 @@
+#ifndef JIT_THUNK_HPP
+#define JIT_THUNK_HPP
+
+#include "src/jit/environment.h"
+
+namespace wabt {
+namespace jit {
+
+Result_t InterpThunk(ThreadInfo* th, Index ind);
+Result_t HostCallThunk(ThreadInfo* th, Index ind);
+
+}
+}
+
+#endif

--- a/src/jit/type-dictionary.cc
+++ b/src/jit/type-dictionary.cc
@@ -35,4 +35,21 @@ wabt::jit::TypeDictionary::TypeDictionary() : TR::TypeDictionary() {
     UnionField("Value", "f64", toIlType<double>(this));
     UnionField("Value", "__size_pad", LookupStruct("ValueSizePad"));
     CloseUnion("Value");
+
+    DefineStruct("CallFrame");
+    DefineField("CallFrame", "pc", toIlType<IstreamOffset>(this));
+    DefineField("CallFrame", "is_jit", Int8);
+    DefineField("CallFrame", "is_jit_compiling", Int8);
+    CloseStruct("CallFrame");
+
+    auto pCallFrame = PointerTo(LookupStruct("CallFrame"));
+
+    DefineStruct("ThreadInfo");
+    DefineField("ThreadInfo", "pc", Int32);
+    DefineField("ThreadInfo", "in_jit", Int32);
+    DefineField("ThreadInfo", "call_stack_max", pCallFrame);
+    DefineField("ThreadInfo", "call_stack", pCallFrame);
+    DefineField("ThreadInfo", "jit_fn_table", toIlType<void**>(this));
+    DefineField("ThreadInfo", "thread", toIlType<void*>(this));
+    CloseStruct("ThreadInfo");
 }

--- a/src/jit/wabtjit.h
+++ b/src/jit/wabtjit.h
@@ -19,11 +19,10 @@
 
 #include "src/common.h"
 #include "src/interp/interp.h"
+#include "src/jit/environment.h"
 
 namespace wabt {
 namespace jit {
-
-using JITedFunction = interp::Result (*)();
 
 JITedFunction compile(interp::Thread* thread, interp::DefinedFunc* fn);
 

--- a/test/interp/basic-tracing.txt
+++ b/test/interp/basic-tracing.txt
@@ -22,7 +22,7 @@
 (;; STDOUT ;;;
 >>> running export "main":
 #0.  100: V:0  | i32.const 3
-#0.  108: V:1  | call @0
+#0.  108: V:1  | call $0
 #1.    0: V:1  | local.get $1
 #1.    8: V:2  | i32.const 1
 #1.   16: V:3  | i32.le_s 3, 1
@@ -30,7 +30,7 @@
 #1.   44: V:1  | local.get $1
 #1.   52: V:2  | i32.const 1
 #1.   60: V:3  | i32.sub 3, 1
-#1.   64: V:2  | call @0
+#1.   64: V:2  | call $0
 #2.    0: V:2  | local.get $1
 #2.    8: V:3  | i32.const 1
 #2.   16: V:4  | i32.le_s 2, 1
@@ -38,7 +38,7 @@
 #2.   44: V:2  | local.get $1
 #2.   52: V:3  | i32.const 1
 #2.   60: V:4  | i32.sub 2, 1
-#2.   64: V:3  | call @0
+#2.   64: V:3  | call $0
 #3.    0: V:3  | local.get $1
 #3.    8: V:4  | i32.const 1
 #3.   16: V:5  | i32.le_s 1, 1

--- a/test/interp/logging-all-opcodes.txt
+++ b/test/interp/logging-all-opcodes.txt
@@ -10842,12 +10842,12 @@ EndModule
   64| return
   68| return
   72| return
-  76| call @0
+  76| call $1
   84| return
   88| i32.const 1
   96| call_indirect $0:0, %[-1]
  108| return
- 112| return_call @0
+ 112| return_call $1
  120| return
  124| i32.const 1
  132| return_call_indirect $0:0, %[-1]

--- a/test/interp/tracing-all-opcodes.txt
+++ b/test/interp/tracing-all-opcodes.txt
@@ -457,7 +457,7 @@ br_table() =>
 #0.   68: V:0  | return
 return() =>
 >>> running export "call":
-#0.   76: V:0  | call @0
+#0.   76: V:0  | call $1
 #1.    0: V:0  | return
 #0.   84: V:0  | return
 call() =>
@@ -468,7 +468,7 @@ call() =>
 #0.  108: V:0  | return
 call_indirect() =>
 >>> running export "return_call":
-#0.  112: V:0  | return_call @0
+#0.  112: V:0  | return_call $1
 #0.    0: V:0  | return
 return_call() =>
 >>> running export "return_call_indirect":

--- a/test/jit/call_complex.txt
+++ b/test/jit/call_complex.txt
@@ -1,0 +1,300 @@
+;;; TOOL: run-interp-minimal
+(module
+  ;; TODO: Find a better way to prevent JIT compilation than using memory.size
+  (memory 0)
+  (table anyfunc (elem $i_id $j_id $i2j_direct $i2j_indirect $j2i_direct $j2i_indirect))
+
+  (type $id (func (param i32) (result i32)))
+  (type $bin (func (param i32 i32) (result i32)))
+
+  (func $i_id (param i32) (result i32)
+    memory.size
+    drop
+    local.get 0)
+
+  (func $j_id (param i32) (result i32)
+    local.get 0)
+
+  (func $i2j_direct (param i32 i32) (result i32) (local i32)
+    memory.size
+    drop
+    local.get 0
+    local.get 1
+    i32.mul
+    local.set 2
+    local.get 0
+    call $j_id
+    local.get 2
+    i32.add)
+
+  (func $j2i_direct (param i32 i32) (result i32) (local i32)
+    local.get 0
+    local.get 1
+    i32.mul
+    local.set 2
+    local.get 0
+    call $i_id
+    local.get 2
+    i32.add)
+
+  (func $j2j_direct (param i32 i32) (result i32) (local i32)
+    local.get 0
+    local.get 1
+    i32.mul
+    local.set 2
+    local.get 0
+    call $j_id
+    local.get 2
+    i32.add)
+
+  (func $i2j_indirect (param i32 i32) (result i32) (local i32)
+    memory.size
+    drop
+    local.get 0
+    local.get 1
+    i32.mul
+    local.set 2
+    local.get 0
+    i32.const 1 ;; $j_id
+    call_indirect (type $id)
+    local.get 2
+    i32.add)
+
+  (func $j2i_indirect (param i32 i32) (result i32) (local i32)
+    local.get 0
+    local.get 1
+    i32.mul
+    local.set 2
+    local.get 0
+    i32.const 0 ;; $i_id
+    call_indirect (type $id)
+    local.get 2
+    i32.add)
+
+  (func $j2j_indirect (param i32 i32) (result i32) (local i32)
+    local.get 0
+    local.get 1
+    i32.mul
+    local.set 2
+    local.get 0
+    i32.const 1 ;; $j_id
+    call_indirect (type $id)
+    local.get 2
+    i32.add)
+
+  (func $call_complex_0 (result i32)
+    i32.const 2
+    i32.const 3
+    call $i2j_direct
+    i32.const 5
+    i32.const 1
+    call $i2j_direct
+    i32.add)
+
+  (func (export "test_call_complex_0") (result i32)
+    call $call_complex_0
+    call $call_complex_0
+    i32.add)
+
+  (func $call_complex_1 (result i32)
+    i32.const 2
+    i32.const 3
+    call $j2i_direct
+    i32.const 5
+    i32.const 1
+    call $j2i_direct
+    i32.add)
+
+  (func (export "test_call_complex_1") (result i32)
+    call $call_complex_1
+    call $call_complex_1
+    i32.add)
+
+  (func $call_complex_2 (result i32)
+    i32.const 2
+    i32.const 3
+    call $j2i_direct
+    i32.const 5
+    i32.const 1
+    call $i2j_direct
+    i32.add)
+
+  (func (export "test_call_complex_2") (result i32)
+    call $call_complex_2
+    call $call_complex_2
+    i32.add)
+
+  (func $call_complex_3 (result i32)
+    i32.const 2
+    i32.const 3
+    call $i2j_direct
+    i32.const 5
+    i32.const 1
+    call $j2i_direct
+    i32.add)
+
+  (func (export "test_call_complex_3") (result i32)
+    call $call_complex_3
+    call $call_complex_3
+    i32.add)
+
+  (func $call_complex_4 (result i32)
+    i32.const 2
+    i32.const 3
+    call $i2j_indirect
+    i32.const 5
+    i32.const 1
+    call $j2i_direct
+    i32.add)
+
+  (func (export "test_call_complex_4") (result i32)
+    call $call_complex_4
+    call $call_complex_4
+    i32.add)
+
+  (func $call_complex_5 (result i32)
+    i32.const 2
+    i32.const 3
+    call $j2i_indirect
+    i32.const 5
+    i32.const 1
+    call $j2j_direct
+    i32.add)
+
+  (func (export "test_call_complex_5") (result i32)
+    call $call_complex_5
+    call $call_complex_5
+    i32.add)
+
+  (func $call_complex_6 (result i32)
+    i32.const 2
+    i32.const 3
+    call $j2j_indirect
+    i32.const 5
+    i32.const 1
+    call $j2i_direct
+    i32.add)
+
+  (func (export "test_call_complex_6") (result i32)
+    call $call_complex_6
+    call $call_complex_6
+    i32.add)
+
+  (func $call_complex_7 (result i32)
+    i32.const 2
+    i32.const 3
+    call $j2j_direct
+    i32.const 5
+    i32.const 1
+    call $j2i_indirect
+    i32.add)
+
+  (func (export "test_call_complex_7") (result i32)
+    call $call_complex_7
+    call $call_complex_7
+    i32.add)
+
+  (func $call_complex_8 (result i32)
+    i32.const 2
+    i32.const 3
+    call $j2j_indirect
+    i32.const 5
+    i32.const 1
+    call $j2j_indirect
+    i32.add)
+
+  (func (export "test_call_complex_8") (result i32)
+    call $call_complex_8
+    call $call_complex_8
+    i32.add)
+
+  (func $call_complex_9 (result i32)
+    i32.const 2
+    i32.const 3
+    call $j2i_indirect
+    i32.const 5
+    i32.const 1
+    call $j2j_indirect
+    i32.add)
+
+  (func (export "test_call_complex_9") (result i32)
+    call $call_complex_9
+    call $call_complex_9
+    i32.add)
+
+  (func $call_complex_10 (result i32)
+    i32.const 2
+    i32.const 3
+    i32.const 2 ;; $i2j_direct
+    call_indirect (type $bin)
+    i32.const 5
+    i32.const 1
+    call $j2i_direct
+    i32.add)
+
+  (func (export "test_call_complex_10") (result i32)
+    call $call_complex_10
+    call $call_complex_10
+    i32.add)
+
+  (func $call_complex_11 (result i32)
+    i32.const 2
+    i32.const 3
+    i32.const 3 ;; $i2j_indirect
+    call_indirect (type $bin)
+    i32.const 5
+    i32.const 1
+    call $j2i_direct
+    i32.add)
+
+  (func (export "test_call_complex_11") (result i32)
+    call $call_complex_11
+    call $call_complex_11
+    i32.add)
+
+  (func $call_complex_12 (result i32)
+    i32.const 2
+    i32.const 3
+    i32.const 4 ;; $j2i_direct
+    call_indirect (type $bin)
+    i32.const 5
+    i32.const 1
+    call $j2i_direct
+    i32.add)
+
+  (func (export "test_call_complex_12") (result i32)
+    call $call_complex_12
+    call $call_complex_12
+    i32.add)
+
+  (func $call_complex_13 (result i32)
+    i32.const 2
+    i32.const 3
+    i32.const 5 ;; $j2i_indirect
+    call_indirect (type $bin)
+    i32.const 5
+    i32.const 1
+    call $j2i_direct
+    i32.add)
+
+  (func (export "test_call_complex_13") (result i32)
+    call $call_complex_13
+    call $call_complex_13
+    i32.add)
+)
+(;; STDOUT ;;;
+test_call_complex_0() => i32:36
+test_call_complex_1() => i32:36
+test_call_complex_2() => i32:36
+test_call_complex_3() => i32:36
+test_call_complex_4() => i32:36
+test_call_complex_5() => i32:36
+test_call_complex_6() => i32:36
+test_call_complex_7() => i32:36
+test_call_complex_8() => i32:36
+test_call_complex_9() => i32:36
+test_call_complex_10() => i32:36
+test_call_complex_11() => i32:36
+test_call_complex_12() => i32:36
+test_call_complex_13() => i32:36
+;;; STDOUT ;;)


### PR DESCRIPTION
Previously, in order to call another function from within a JITted
function, it was necessary to call a helper function. This incurred an
unnecessary amount of overhead when calling JITted functions from other
JITted functions.

In order to make calls more lightweight, a new dispatch system has been
introduced. Instead of calling a helper, direct function calls from
JITted code will now instead be made via a table accessible to JITted
code. For interpreted and host functions, this table will be populated
with function pointers to thunks which will perform the necessary
transition. Once a function has been JITted, its entry in the table will
be replaced with a pointer directly to the JITted function, allowing the
helper to be bypassed entirely.