### PR TITLE
Improve memory access speed from JITted code

### DIFF
--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -22,6 +22,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include <unordered_map>
@@ -121,13 +122,45 @@ struct Table {
   std::vector<Index> func_indexes;
 };
 
+struct MemoryData {
+  size_t capacity_;
+  size_t size_;
+  char* data_;
+
+  MemoryData(size_t size_);
+  MemoryData(const MemoryData&) = delete;
+  MemoryData(MemoryData&&);
+
+  ~MemoryData();
+
+  MemoryData& operator=(const MemoryData&) = delete;
+  MemoryData& operator=(MemoryData&&);
+
+  char& operator[](size_t i) { return *(data_ + i); }
+  const char& operator[](size_t i) const { return *(data_ + i); }
+
+  size_t size() const noexcept { return size_; }
+
+  char* begin() noexcept { return data_; }
+  const char* cbegin() const noexcept { return data_; }
+
+  char* end() noexcept { return data_ + size_; }
+  const char* cend() const noexcept { return data_ + size_; }
+
+  char* data() noexcept { return data_; }
+  const char* data() const noexcept { return data_; }
+
+  void resize(size_t size);
+};
+static_assert(std::is_standard_layout<MemoryData>::value, "MemoryData must be standard layout");
+
 struct Memory {
   Memory() = default;
   explicit Memory(const Limits& limits)
       : page_limits(limits), data(limits.initial * WABT_PAGE_SIZE) {}
 
   Limits page_limits;
-  std::vector<char> data;
+  MemoryData data;
 };
 
 struct DataSegment {

--- a/src/jit/function-builder.h
+++ b/src/jit/function-builder.h
@@ -129,8 +129,6 @@ class FunctionBuilder : public TR::MethodBuilder {
 
   static Result_t CallIndirectHelper(ThreadInfo* th, Index table_index, Index sig_index, Index entry_index);
 
-  static void* MemoryTranslationHelper(interp::Thread* th, uint32_t memory_id, uint64_t address, uint32_t size);
-
   std::vector<BytecodeWorkItem> workItems_;
 
   interp::Thread* thread_;

--- a/src/jit/type-dictionary.cc
+++ b/src/jit/type-dictionary.cc
@@ -52,4 +52,10 @@ wabt::jit::TypeDictionary::TypeDictionary() : TR::TypeDictionary() {
     DefineField("ThreadInfo", "jit_fn_table", toIlType<void**>(this));
     DefineField("ThreadInfo", "thread", toIlType<void*>(this));
     CloseStruct("ThreadInfo");
+
+    DefineStruct("MemoryData");
+    DefineField("MemoryData", "capacity", toIlType<size_t>(this));
+    DefineField("MemoryData", "size", toIlType<size_t>(this));
+    DefineField("MemoryData", "data", toIlType<void*>(this));
+    CloseStruct("MemoryData");
 }


### PR DESCRIPTION
Previously, it was necessary for JITted code to use a helper to perform memory operations. This was due to the fact that linear memories were represented using a `std::vector<char>`, which is not a standard  layout type and is thus not possible to access from JITted code without potential UB. This helper was appearing to be taking up an increasing proportion of time in profiles and a solution was needed to perform memory accesses from JITted code without using a helper.

This PR changes the way that linear memories work in the VM to use a custom standard layout type instead of `std::vector<char>`, making it possible to read information about memory from JITted code. This allows memory accesses from JITted code to avoid calling helpers and thus significantly improves performance.